### PR TITLE
In Python3 range does not return a list

### DIFF
--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -1243,7 +1243,7 @@ class GAM(Core):
         if max_ == limit:
             # subsampling
             scale = np.float(size)/max_
-            idxs = range(size)
+            idxs = list(range(size))
             np.random.shuffle(idxs)
 
             if B is None:


### PR DESCRIPTION
Now Pygam can be run on Python3(tested on Debian 9 with Python 3.5) without any problem;
It would return:
...
TypeError: 'range' object does not support item assignment

before.