### PR TITLE
Minor fix in docstring of gridsearch

### DIFF
--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -1650,7 +1650,7 @@ class GAM(Core):
 
         Returns
         -------
-        if return_values == True:
+        if return_scores == True:
             model_scores : dict
                 Contains each fitted model as keys and corresponding
                 objective scores as values


### PR DESCRIPTION
Change `return_values` to `return_scores` in the "Returns" section of the docstring of `gridsearch`.

It looks like `return_values` was an initial choice for the parameter that was later changed to `return_scores`, but this name was not updated in the end of the docstring.