### PR TITLE
[WIP] Fix PoissonGAM Optimization

### DIFF
--- a/pygam/distributions.py
+++ b/pygam/distributions.py
@@ -376,7 +376,7 @@ class PoissonDist(Distribution):
         # so we want to pump up all our predictions
         # NOTE: we assume the targets are unchanged
         mu = mu * weights
-        return (mu**y) * np.exp(-mu) / sp.misc.factorial(y)
+        return (mu ** y) * np.exp(-mu) / sp.special.factorial(y)
 
     @divide_weights
     def V(self, mu):

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -926,8 +926,12 @@ class GAM(Core):
         -------
         weights : sp..sparse array of shape (n_samples, n_samples)
         """
-        return sp.sparse.diags((self.link.gradient(mu, self.distribution)**2 *
-                                self.distribution.V(mu=mu) *
+        # return sp.sparse.diags((self.link.gradient(mu, self.distribution)**2 *
+        #                         self.distribution.V(mu=mu) *
+        #                         weights ** -1)**-0.5)
+
+        return sp.sparse.diags(self.link.gradient(mu, self.distribution) *
+                                (self.distribution.V(mu=mu) *
                                 weights ** -1)**-0.5)
 
     def _mask(self, weights):
@@ -953,6 +957,23 @@ class GAM(Core):
         assert mask.sum() != 0, 'increase regularization'
         return mask
 
+    def centering_constraint(self):
+        p = np.sum(self._n_splines)
+        m = len(self._n_splines)
+
+        C = [np.zeros(p)] if self._fit_intercept else []
+        pre = 0
+        for n_splines in self._n_splines:
+            row = np.zeros(p)
+            row[pre : pre + n_splines] = 1
+            C.append(row)
+
+            pre += n_splines
+
+        C = np.stack(C, axis=0)
+        U, P = np.linalg.qr(C.T, mode='complete')
+        return U[:, m:]
+
     def _pirls(self, X, Y, weights):
         """
         Performs stable PIRLS iterations to estimate GAM coefficients
@@ -973,14 +994,17 @@ class GAM(Core):
         modelmat = self._modelmat(X) # build a basis matrix for the GLM
         n, m = modelmat.shape
 
+        centering_op = self._centering_constraint()
+
         # initialize GLM coefficients
         if not self._is_fitted or len(self.coef_) != sum(self._n_coeffs):
             self.coef_ = np.ones(m) * np.sqrt(EPS) # allow more training
+            coef_z = np.ones_like(centering_op) * np.sqrt(EPS) # allow more training
 
         # do our penalties require recomputing cholesky?
         chol_pen = np.ravel([np.ravel(p) for p in self._penalties])
         chol_pen = any([cp in ['convex', 'concave', 'monotonic_inc',
-                               'monotonic_dec', 'circular']for cp in chol_pen])
+                               'monotonic_dec', 'circular'] for cp in chol_pen])
         P = self._P() # create penalty matrix
 
         # base penalty
@@ -1004,9 +1028,12 @@ class GAM(Core):
 
             # forward pass
             y = deepcopy(Y) # for simplicity
-            lp = self._linear_predictor(modelmat=modelmat)
-            mu = self.link.mu(lp, self.distribution)
+            lp = self._linear_predictor(modelmat=modelmat, b=coef_)
+            mu = self.link.mu(lp, self.distribution) + EPS * .00001
             W = self._W(mu, weights) # create pirls weight matrix
+
+            # print('mu ', mu.max(), mu.min())
+            print(mu)
 
             # check for weghts == 0, nan, and update
             mask = self._mask(W.diagonal())
@@ -1017,6 +1044,7 @@ class GAM(Core):
 
             # PIRLS Wood pg 183
             pseudo_data = W.dot(self._pseudo_data(y, lp, mu))
+            # print('pseudo data ', pseudo_data.max(), pseudo_data.min())
 
             # log on-loop-start stats
             self._on_loop_start(vars())
@@ -1042,6 +1070,7 @@ class GAM(Core):
             # update coefficients
             B = Vt.T.dot(Dinv).dot(U1.T).dot(Q.T)
             coef_new = B.dot(pseudo_data).A.flatten()
+            # print('coefs ', coef_new)
             diff = np.linalg.norm(self.coef_ - coef_new)/np.linalg.norm(coef_new)
             self.coef_ = coef_new # update
 
@@ -1061,7 +1090,7 @@ class GAM(Core):
         print('did not converge')
         return
 
-    def _pirls_naive(self, X, y):
+    def _pirls_naive(self, X, y, weights):
         """
         Performs naive PIRLS iterations to estimate GAM coefficients
 
@@ -1094,20 +1123,23 @@ class GAM(Core):
             mu = mu[mask] # update
             lp = lp[mask] # update
 
-            if self.family == 'binomial':
-                self.acc.append(self.accuracy(y=y[mask], mu=mu)) # log the training accuracy
-            self.dev.append(self.deviance_(y=y[mask], mu=mu, scaled=False)) # log the training deviance
+            # if self.family == 'binomial':
+            #     self.acc.append(self.accuracy(y=y[mask], mu=mu)) # log the training accuracy
+            # self.logs_['deviance'].append(self.deviance_(y=y[mask], mu=mu, scaled=False)) # log the training deviance
 
-            weights = self._W(mu)**2 # PIRLS, added square for modularity
-            pseudo_data = self._pseudo_data(y, lp, mu) # PIRLS
+            W = self._W(mu, weights[mask])**2 # PIRLS, added square for modularity
+            pseudo_data = self._pseudo_data(y[mask], lp, mu) # PIRLS
 
-            BW = modelmat.T.dot(weights).tocsc() # common matrix product
-            inner = sp.sparse.linalg.inv(BW.dot(modelmat) + P) # keep for edof
+            BW = modelmat[mask].T.dot(W).tocsc() # common matrix product
+            inner = sp.sparse.linalg.inv(BW.dot(modelmat[mask]) + P + sp.sparse.eye(*(P.shape))*0.0001) # keep for edof
 
             coef_new = inner.dot(BW).dot(pseudo_data).flatten()
             diff = np.linalg.norm(self.coef_ - coef_new)/np.linalg.norm(coef_new)
-            self.diffs.append(diff)
+            self.logs_['diffs'].append(diff)
             self.coef_ = coef_new # update
+
+            # log on-loop-end stats
+            self._on_loop_end(vars())
 
             # check convergence
             if diff < self.tol:
@@ -1200,7 +1232,7 @@ class GAM(Core):
         if self._opt == 0:
             self._pirls(X, y, weights)
         if self._opt == 1:
-            self._pirls_naive(X, y)
+            self._pirls_naive(X, y, weights)
         return self
 
     def deviance_residuals(self, X, y, weights=None, scaled=False):
@@ -1888,7 +1920,7 @@ class GAM(Core):
                 # try fitting
                 gam.fit(X, y, weights)
 
-            except ValueError as error:
+            except (ValueError, AssertionError) as error:
                 msg = str(error) + '\non model:\n' + str(gam)
                 msg += '\nskipping...\n'
                 warnings.warn(msg)

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -957,7 +957,7 @@ class GAM(Core):
         assert mask.sum() != 0, 'increase regularization'
         return mask
 
-    def centering_constraint(self):
+    def _centering_constraint(self):
         p = np.sum(self._n_splines)
         m = len(self._n_splines)
 

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -926,13 +926,13 @@ class GAM(Core):
         -------
         weights : sp..sparse array of shape (n_samples, n_samples)
         """
-        # return sp.sparse.diags((self.link.gradient(mu, self.distribution)**2 *
-        #                         self.distribution.V(mu=mu) *
-        #                         weights ** -1)**-0.5)
-
-        return sp.sparse.diags(self.link.gradient(mu, self.distribution) *
-                                (self.distribution.V(mu=mu) *
+        return sp.sparse.diags((self.link.gradient(mu, self.distribution)**2 *
+                                self.distribution.V(mu=mu) *
                                 weights ** -1)**-0.5)
+
+        # return sp.sparse.diags(self.link.gradient(mu, self.distribution) *
+        #                         (self.distribution.V(mu=mu) *
+        #                         weights ** -1)**-0.5)
 
     def _mask(self, weights):
         """
@@ -999,7 +999,7 @@ class GAM(Core):
         # initialize GLM coefficients
         if not self._is_fitted or len(self.coef_) != sum(self._n_coeffs):
             self.coef_ = np.ones(m) * np.sqrt(EPS) # allow more training
-            coef_z = np.ones_like(centering_op) * np.sqrt(EPS) # allow more training
+            # coef_z = np.ones_like(centering_op) * np.sqrt(EPS) # allow more training
 
         # do our penalties require recomputing cholesky?
         chol_pen = np.ravel([np.ravel(p) for p in self._penalties])
@@ -1028,8 +1028,8 @@ class GAM(Core):
 
             # forward pass
             y = deepcopy(Y) # for simplicity
-            lp = self._linear_predictor(modelmat=modelmat, b=coef_)
-            mu = self.link.mu(lp, self.distribution) + EPS * .00001
+            lp = self._linear_predictor(modelmat=modelmat)#, b=self.coef_)
+            mu = self.link.mu(lp, self.distribution) #+ EPS * .00001
             W = self._W(mu, weights) # create pirls weight matrix
 
             # print('mu ', mu.max(), mu.min())


### PR DESCRIPTION
Currently PoissonGAM has convergence bugs as pointed out in https://github.com/dswah/pyGAM/issues/150. 
  
I believe the root cause is 2-fold:
1. dimension mismatch: caused by forgetting to update the SVD shape on every PIRLS iteration. this is needed because the binary mask can change on each iteration.
2. overflow due to exp (ie inverse link of the the log-link) in Poisson regression. when response data is too large (~1e3) we get overflow when computing `exp(mu)`. 
  
This would be solved by:
1.  recomputing the target SVD shape in each PIRLS iteration.
2. a.  scaling the response data by its maximum value solves overflow and leads to convergence. (possibly treating as an additional exposure)
b.  ensuring that model diagnostics account for a scaled response variable.
  
Tasks:
- [ ] replicate error in https://github.com/dswah/pyGAM/issues/150 (currently i've replicated a similar error)
- [x] update SVD shapes inside PIRLS loop. important for changing mask shapes.
- [ ] normalize / un-normalize response data in Poisson. Y-data ~ 1e3 leads to overflow and diverging optimization.
- [ ] poisson results are the same as the unaltered algorithm on non-overflowing data
- [ ] test convergence of poisson model for large response values