### PR TITLE
added setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+setup
+
+Module installs pyGAM package
+
+Can be run via command: python setup.py install (or python setup.py develop)
+"""
+
+from setuptools import setup, find_packages
+
+
+with open('README.md') as f:
+    readme = f.read()
+
+with open('LICENSE') as f:
+    license = f.read()
+
+with open('requirements.txt') as f:
+    requirements = f.read()
+    requirements = [req for req in requirements.split('\n') if len(req) > 0]
+
+args = dict(
+    name='pyGAM',
+    long_description=readme,
+    license=license,
+    version='0.5.2',
+    packages=find_packages(exclude=('datasets', 'imgs', 'tests')),
+    install_requires=requirements
+)
+
+setup(**args)


### PR DESCRIPTION
I was trying to debug an issue I encountered with the package (see #174) and the best way to do so (in my case) was to install with the ```develop``` option, so I created a bare-bones setup.py script.

This addition seems broadly useful for new contributors as well, since a potential contributor can make additions/changes to the code base with the develop option instead of adding the package to their python path.