### PR TITLE
Better initial values

### DIFF
--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -993,6 +993,8 @@ class GAM(Core):
         y = deepcopy(y)
         y[y == 0] += .01 # edge case for log link, inverse link, and logit link
         y[y == 1] -= .01 # edge case for logit link
+        assert np.isfinite(y_), "transformed response values should be well-behaved."
+
         y_ = self.link.link(y, self.distribution)
         y_ = make_2d(y_)
 

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -998,7 +998,11 @@ class GAM(Core):
 
         # solve the linear problem
         modelmat = modelmat.A
-        return np.linalg.solve(load_diagonal(modelmat.T.dot(modelmat)), modelmat.T.dot(y_))
+        return np.linalg.solve(load_diagonal(modelmat.T.dot(modelmat)),
+                               modelmat.T.dot(y_))
+
+        # not sure if this is faster...
+        # return np.linalg.pinv(modelmat.T.dot(modelmat)).dot(modelmat.T.dot(y_))
 
     def _pirls(self, X, Y, weights):
         """

--- a/pygam/utils.py
+++ b/pygam/utils.py
@@ -442,6 +442,19 @@ def get_link_domain(link, dist):
     domain = domain[~np.isnan(link.link(domain, dist))]
     return [domain[0], domain[-1]]
 
+
+def load_diagonal(cov, load=None):
+        """Return the given square matrix with a small amount added to the diagonal
+        to make it positive semi-definite.
+        """
+        n, m = cov.shape
+        assert n == m, "matrix must be square, but found shape {}".format((n, m))
+
+        if load is None:
+            load = np.sqrt(np.finfo(np.float64).eps) # machine epsilon
+        return cov + np.eye(n) * load
+
+
 def round_to_n_decimal_places(array, n=3):
     """
     tool to keep round a float to n decimal places.

--- a/pygam/utils.py
+++ b/pygam/utils.py
@@ -24,6 +24,10 @@ class NotPositiveDefiniteError(ValueError):
     """Exception class to raise if a matrix is not positive definite
     """
 
+class OptimizationError(ValueError):
+    """Exception class to raise if PIRLS optimization fails
+    """
+
 
 def cholesky(A, sparse=True, verbose=True):
     """


### PR DESCRIPTION
Make better initial value estimates by transforming the problem to the linear space, and solving the un-penalized least-squares problem. The problem is later transformed back, the penalty is added and optimization continues...

solves https://github.com/dswah/pyGAM/issues/174 and https://github.com/dswah/pyGAM/issues/150

- [x] Special treatment for LinearGAM where this would be redundant.