### PR TITLE
Poisson bug

### DIFF
--- a/pygam/distributions.py
+++ b/pygam/distributions.py
@@ -376,7 +376,6 @@ class PoissonDist(Distribution):
         # so we want to pump up all our predictions
         # NOTE: we assume the targets are unchanged
         mu = mu * weights
-
         return sp.stats.poisson.logpmf(np.array(y, dtype='i'), mu=mu)
 
     @divide_weights

--- a/pygam/distributions.py
+++ b/pygam/distributions.py
@@ -376,7 +376,8 @@ class PoissonDist(Distribution):
         # so we want to pump up all our predictions
         # NOTE: we assume the targets are unchanged
         mu = mu * weights
-        return sp.stats.poisson.logpmf(y, mu=mu)
+
+        return sp.stats.poisson.logpmf(np.array(y, dtype='i'), mu=mu)
 
     @divide_weights
     def V(self, mu):

--- a/pygam/distributions.py
+++ b/pygam/distributions.py
@@ -374,9 +374,14 @@ class PoissonDist(Distribution):
             weights = np.ones_like(mu)
         # in Poisson regression weights are proportional to the exposure
         # so we want to pump up all our predictions
-        # NOTE: we assume the targets are unchanged
+        # NOTE: we assume the targets are counts, not rate.
+        # ie if observations were scaled to account for exposure, they have
+        # been rescaled before calling this function.
+        # since some samples have higher exposure,
+        # they also need to have higher variance,
+        # we do this by multiplying mu by the weight=exposure
         mu = mu * weights
-        return sp.stats.poisson.logpmf(np.array(y, dtype='i'), mu=mu)
+        return sp.stats.poisson.logpmf(y, mu=mu)
 
     @divide_weights
     def V(self, mu):

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -3013,7 +3013,7 @@ class PoissonGAM(GAM):
             containing log-likelihood scores
         """
         if rescale_y:
-            y = y * weights
+            y = np.round(y * weights).astype('int')
 
         return self.distribution.log_pdf(y=y, mu=mu, weights=weights).sum()
 
@@ -3098,6 +3098,8 @@ class PoissonGAM(GAM):
         check_lengths(weights, exposure)
 
         # set exposure as the weight
+        # we do this because we have divided our response
+        # so if we make an error of 1 now, we need it to count more heavily.
         weights = weights * exposure
 
         return y, weights

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -3005,7 +3005,9 @@ class PoissonGAM(GAM):
         weights : array-like of shape (n,)
             containing sample weights
         rescale_y : boolean, defaul: True
-            whether to scale the targets back up by
+            whether to scale the targets back up.
+            useful when fitting with an exposure, in which case the count observations
+            were scaled into rates. this rescales rates into counts.
 
         Returns
         -------

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -588,7 +588,9 @@ class GAM(Core):
         mu = self.predict_mu(X)
 
         if weights is not None:
-            weights = check_array(weights, name='sample weights', verbose=self.verbose)
+            weights = np.array(weights).astype('f').ravel()
+            weights = check_array(weights, name='sample weights',
+                                  ndim=1, verbose=self.verbose)
             check_lengths(y, weights)
         else:
             weights = np.ones_like(y).astype('float64')
@@ -1251,7 +1253,9 @@ class GAM(Core):
         check_X_y(X, y)
 
         if weights is not None:
-            weights = check_array(weights, name='sample weights', verbose=self.verbose)
+            weights = np.array(weights).astype('f').ravel()
+            weights = check_array(weights, name='sample weights',
+                                  ndim=1, verbose=self.verbose)
             check_lengths(y, weights)
         else:
             weights = np.ones_like(y).astype('float64')
@@ -1303,7 +1307,9 @@ class GAM(Core):
         check_X_y(X, y)
 
         if weights is not None:
-            weights = check_array(weights, name='sample weights', verbose=self.verbose)
+            weights = np.array(weights).astype('f').ravel()
+            weights = check_array(weights, name='sample weights',
+                                  ndim=1, verbose=self.verbose)
             check_lengths(y, weights)
         else:
             weights = np.ones_like(y).astype('float64')
@@ -2013,7 +2019,9 @@ class GAM(Core):
         check_X_y(X, y)
 
         if weights is not None:
-            weights = check_array(weights, name='sample weights', verbose=self.verbose)
+            weights = np.array(weights).astype('f').ravel()
+            weights = check_array(weights, name='sample weights',
+                                  ndim=1, verbose=self.verbose)
             check_lengths(y, weights)
         else:
             weights = np.ones_like(y).astype('float64')
@@ -3034,7 +3042,9 @@ class PoissonGAM(GAM):
         mu = self.predict_mu(X)
 
         if weights is not None:
-            weights = check_array(weights, name='sample weights', verbose=self.verbose)
+            weights = np.array(weights).astype('f').ravel()
+            weights = check_array(weights, name='sample weights',
+                                  ndim=1, verbose=self.verbose)
             check_lengths(y, weights)
         else:
             weights = np.ones_like(y).astype('float64')
@@ -3063,18 +3073,26 @@ class PoissonGAM(GAM):
         y : y normalized by exposure
         weights : array-like shape (n_samples,)
         """
+        y = y.ravel()
 
         if exposure is not None:
-            exposure = np.array(exposure).astype('f')
+            exposure = np.array(exposure).astype('f').ravel()
+            exposure = check_array(exposure, name='sample exposure',
+                                   ndim=1, verbose=self.verbose)
         else:
-            exposure = np.ones_like(y).astype('float64')
+            exposure = np.ones_like(y.ravel()).astype('float64')
+
+        # check data
+        exposure = exposure.ravel()
         check_lengths(y, exposure)
 
         # normalize response
         y = y / exposure
 
         if weights is not None:
-            weights = np.array(weights).astype('f')
+            weights = np.array(weights).astype('f').ravel()
+            weights = check_array(weights, name='sample weights',
+                                  ndim=1, verbose=self.verbose)
         else:
             weights = np.ones_like(y).astype('float64')
         check_lengths(weights, exposure)

--- a/pygam/tests/test_GAM_methods.py
+++ b/pygam/tests/test_GAM_methods.py
@@ -16,477 +16,500 @@ def mcycle_gam(mcycle_X_y):
     gam = LinearGAM().fit(X,y)
     return gam
 
-def test_LinearGAM_pdeps_shape(wage_X_y):
-    """
-    check that we get the expected number of partial dependence functions
-    """
-    X, y = wage_X_y
-    gam = LinearGAM().fit(X, y)
-    pdeps = gam.partial_dependence(X)
-    assert(X.shape == pdeps.shape)
-
-def test_LinearGAM_prediction(mcycle_X_y, mcycle_gam):
-    """
-    check that we the predictions we get are correct shape
-    """
-    X, y = mcycle_X_y
-    preds = mcycle_gam.predict(X)
-    assert(preds.shape == y.shape)
-
-def test_LogisticGAM_accuracy(default_X_y):
-    """
-    check that we can compute accuracy correctly
-    """
-    X, y = default_X_y
-    gam = LogisticGAM().fit(X, y)
-
-    preds = gam.predict(X)
-    acc0 = (preds == y).mean()
-    acc1 = gam.accuracy(X, y)
-    assert(acc0 == acc1)
-
-def test_PoissonGAM_exposure(coal_X_y):
-    """
-    check that we can fit a Poisson GAM with exposure, and it scales predictions
-    """
-    X, y = coal_X_y
-    gam = PoissonGAM().fit(X, y, exposure=np.ones_like(y))
-    assert((gam.predict(X, exposure=np.ones_like(y)*2) == 2 *gam.predict(X)).all())
-
-def test_PoissonGAM_loglike(coal_X_y):
-    """
-    check that our loglikelihood is scaled by exposure
-
-    predictions that are twice as large with twice the exposure
-    should have lower loglikelihood
-    """
-    X, y = coal_X_y
-    exposure = np.ones_like(y)
-    gam_high_var = PoissonGAM().fit(X, y * 2, exposure=exposure * 2)
-    gam_low_var = PoissonGAM().fit(X, y, exposure=exposure)
-
-    assert gam_high_var.loglikelihood(X, y * 2, exposure * 2) < gam_low_var.loglikelihood(X, y, exposure)
-
-def test_large_GAM(coal_X_y):
-    """
-    check that we can fit a GAM in py3 when we have more than 50,000 samples
-    """
-    X = np.linspace(0, 100, 100000)
-    y = X**2
-    gam = LinearGAM().fit(X, y)
-    assert(gam._is_fitted)
-
-def test_summary(mcycle_X_y, mcycle_gam):
-    """
-    check that we can get a summary if we've fitted the model, else not
-    """
-    X, y = mcycle_X_y
-    gam = LinearGAM()
-
-    try:
-      gam.summary()
-    except AttributeError:
-      assert(True)
-
-    mcycle_gam.summary()
-    assert(True)
-
-def test_more_splines_than_samples(mcycle_X_y):
-    """
-    check that gridsearch returns the expected number of models
-    """
-    X, y = mcycle_X_y
-    n = len(X)
-
-    gam = LinearGAM(n_splines=n+1).fit(X, y)
-    assert(gam._is_fitted)
-
-def test_deviance_residuals(mcycle_X_y, mcycle_gam):
-    """
-    for linear GAMs, the deviance residuals should be equal to the y - y_pred
-    """
-    X, y = mcycle_X_y
-    res = mcycle_gam.deviance_residuals(X, y)
-    err = y - mcycle_gam.predict(X)
-    assert((res == err).all())
-
-def test_conf_intervals_return_array(mcycle_X_y, mcycle_gam):
-    """
-    make sure that the confidence_intervals method returns an array
-    """
-    X, y = mcycle_X_y
-    conf_ints = mcycle_gam.confidence_intervals(X)
-    assert(conf_ints.ndim == 2)
-
-def test_conf_intervals_quantiles_width_interchangable(mcycle_X_y, mcycle_gam):
-    """
-    getting confidence_intervals via width or specifying quantiles
-    should return the same result
-    """
-    X, y = mcycle_X_y
-    conf_ints_a = mcycle_gam.confidence_intervals(X, width=.9)
-    conf_ints_b = mcycle_gam.confidence_intervals(X, quantiles=[.05, .95])
-    assert(np.allclose(conf_ints_a, conf_ints_b))
-
-def test_conf_intervals_ordered(mcycle_X_y, mcycle_gam):
-    """
-    comfidence intervals returned via width should be ordered
-    """
-    X, y = mcycle_X_y
-    conf_ints = mcycle_gam.confidence_intervals(X)
-    assert((conf_ints[:,0] <= conf_ints[:,1]).all())
-
-def test_partial_dependence_on_univar_data(mcycle_X_y, mcycle_gam):
-    """
-    partial dependence with univariate data should equal the overall model
-    if fit intercept is false
-    """
-    X, y = mcycle_X_y
-    gam = LinearGAM(fit_intercept=False).fit(X,y)
-    pred = gam.predict(X)
-    pdep = gam.partial_dependence(X)
-    assert((pred == pdep.ravel()).all())
-
-def test_partial_dependence_on_univar_data2(mcycle_X_y, mcycle_gam):
-    """
-    partial dependence with univariate data should NOT equal the overall model
-    if fit intercept is false
-    """
-    X, y = mcycle_X_y
-    gam = LinearGAM(fit_intercept=True).fit(X,y)
-    pred = gam.predict(X)
-    pdep = gam.partial_dependence(X)
-    assert((pred != pdep.ravel()).all())
-
-def test_partial_dependence_feature_doesnt_exist(mcycle_X_y, mcycle_gam):
-    """
-    partial dependence should raise ValueError when requesting a nonexistent
-    feature
-    """
-    X, y = mcycle_X_y
-    try:
-        mcycle_gam.partial_dependence(X, feature=10)
-    except ValueError:
-        assert(True)
-
-def test_summary_returns_12_lines(mcycle_gam):
-    """
-    check that the summary method works and returns 24 lines like:
-
-    LinearGAM
-    =============================================== ==========================================================
-    Distribution:                        NormalDist Effective DoF:                                     11.2495
-    Link Function:                     IdentityLink Log Likelihood:                                   -952.605
-    Number of Samples:                          133 AIC:                                             1929.7091
-                                                    AICc:                                            1932.4197
-                                                    GCV:                                              605.6546
-                                                    Scale:                                            514.2013
-                                                    Pseudo R-Squared:                                   0.7969
-    ==========================================================================================================
-    Feature Function   Data Type      Num Splines   Spline Order  Linear Fit  Lambda     P > x      Sig. Code
-    ================== ============== ============= ============= =========== ========== ========== ==========
-    feature 1          numerical      25            3             False       1.0        3.43e-03   **
-    intercept                                                                            6.85e-02   .
-    ==========================================================================================================
-    Significance codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
-
-    WARNING: Fitting splines and a linear function to a feature introduces a model identifiability problem
-             which can cause p-values to appear significant when they are not.
-
-    WARNING: p-values calculated in this manner behave correctly for un-penalized models or models with
-             known smoothing parameters, but when smoothing parameters have been estimated, the p-values
-             are typically lower than they should be, meaning that the tests reject the null too readily.
-    """
-    if sys.version_info.major == 2:
-        from StringIO import StringIO
-    if sys.version_info.major == 3:
-        from io import StringIO
-    stdout = sys.stdout  #keep a handle on the real standard output
-    sys.stdout = StringIO() #Choose a file-like object to write to
-    mcycle_gam.summary()
-    assert(len(sys.stdout.getvalue().split('\n')) == 24)
-
-def test_is_fitted_predict(mcycle_X_y):
-    """
-    test predict requires fitted model
-    """
-    X, y = mcycle_X_y
-    gam = LinearGAM()
-    try:
-        gam.predict(X)
-    except AttributeError:
-        assert(True)
-
-def test_is_fitted_predict_mu(mcycle_X_y):
-    """
-    test predict_mu requires fitted model
-    """
-    X, y = mcycle_X_y
-    gam = LinearGAM()
-    try:
-        gam.predict_mu(X)
-    except AttributeError:
-        assert(True)
-
-def test_is_fitted_dev_resid(mcycle_X_y):
-    """
-    test deviance_residuals requires fitted model
-    """
-    X, y = mcycle_X_y
-    gam = LinearGAM()
-    try:
-        gam.deviance_residuals(X, y)
-    except AttributeError:
-        assert(True)
-
-def test_is_fitted_conf_intervals(mcycle_X_y):
-    """
-    test confidence_intervals requires fitted model
-    """
-    X, y = mcycle_X_y
-    gam = LinearGAM()
-    try:
-        gam.confidence_intervals(X)
-    except AttributeError:
-        assert(True)
-
-
-def test_is_fitted_pdep(mcycle_X_y):
-    """
-    test partial_dependence requires fitted model
-    """
-    X, y = mcycle_X_y
-    gam = LinearGAM()
-    try:
-        gam.partial_dependence(X)
-    except AttributeError:
-        assert(True)
-
-def test_is_fitted_summary(mcycle_X_y):
-    """
-    test summary requires fitted model
-    """
-    X, y = mcycle_X_y
-    gam = LinearGAM()
-    try:
-        gam.summary()
-    except AttributeError:
-        assert(True)
-
-def test_set_params_with_external_param():
-    """
-    test set_params sets a real parameter
-    """
-    gam = GAM(lam=1)
-    gam.set_params(lam=420)
-    assert(gam.lam == 420)
-
-def test_set_params_with_hidden_param():
-    """
-    test set_params should not set any params that are not exposed to the user
-    """
-    gam = GAM()
-    gam.set_params(_lam=420)
-    assert(gam._lam != 420)
-
-def test_set_params_with_phony_param():
-    """
-    test set_params should not set any phony param
-    """
-    gam = GAM()
-    gam.set_params(cat=420)
-    assert(not hasattr(gam, 'cat'))
-
-def test_set_params_with_hidden_param_deep():
-    """
-    test set_params can set hidden params if we use the deep=True
-    """
-    gam = GAM()
-    assert(gam._lam != 420)
-
-    gam.set_params(_lam=420, deep=True)
-    assert(gam._lam == 420)
-
-def test_set_params_with_phony_param_force():
-    """
-    test set_params can set phony params if we use the force=True
-    """
-    gam = GAM()
-    assert(not hasattr(gam, 'cat'))
-
-    gam.set_params(cat=420, force=True)
-    assert(gam.cat == 420)
-
-def test_get_params():
-    """
-    test gam gets our params
-    """
-    gam = GAM(lam=420)
-    params = gam.get_params()
-    assert(params['lam'] == 420)
-
-def test_get_params_hidden():
-    """
-    test gam gets our params only if we do deep=True
-    """
-    gam = GAM()
-    params = gam.get_params()
-    assert('_lam' not in list(params.keys()))
-
-    params = gam.get_params(deep=True)
-    assert('_lam' in list(params.keys()))
-
-
-class TestSamplingFromPosterior(object):
-
-    def test_drawing_samples_from_unfitted_model(self, mcycle_X_y, mcycle_gam):
-        X, y = mcycle_X_y
-        gam = LinearGAM()
-
-        with pytest.raises(AttributeError):
-            gam.sample(X, y)
-
-        with pytest.raises(AttributeError):
-            gam._sample_coef(X, y)
-
-        with pytest.raises(AttributeError):
-            gam._bootstrap_samples_of_smoothing(X, y)
-
-        assert mcycle_gam._is_fitted
-
-        mcycle_gam.sample(X, y, n_draws=2)
-        mcycle_gam._sample_coef(X, y, n_draws=2)
-        mcycle_gam._bootstrap_samples_of_smoothing(X, y, n_bootstraps=1)
-        assert True
-
-    def test_sample_quantity(self, mcycle_X_y, mcycle_gam):
-        X, y = mcycle_X_y
-        for quantity in ['coefficients', 'response']:
-            with pytest.raises(ValueError):
-                mcycle_gam.sample(X, y, quantity=quantity, n_draws=2)
-        for quantity in ['coef', 'mu', 'y']:
-            mcycle_gam.sample(X, y, quantity=quantity, n_draws=2)
-            assert True
-
-    def test_shape_of_random_samples(self, mcycle_X_y, mcycle_gam):
-        X, y = mcycle_X_y
-        n_samples = len(X)
-        n_draws = 5
-
-        sample_coef = mcycle_gam.sample(X, y, quantity='coef', n_draws=n_draws)
-        sample_mu = mcycle_gam.sample(X, y, quantity='mu', n_draws=n_draws)
-        sample_y = mcycle_gam.sample(X, y, quantity='y', n_draws=n_draws)
-        assert sample_coef.shape == (n_draws, len(mcycle_gam.coef_))
-        assert sample_mu.shape == (n_draws, n_samples)
-        assert sample_y.shape == (n_draws, n_samples)
-
-        XX = generate_X_grid(mcycle_gam)
-        n_samples_in_grid = len(XX)
-        sample_coef = mcycle_gam.sample(X, y, quantity='coef', n_draws=n_draws,
-                                        sample_at_X=XX)
-        sample_mu = mcycle_gam.sample(X, y, quantity='mu', n_draws=n_draws,
-                                        sample_at_X=XX)
-        sample_y = mcycle_gam.sample(X, y, quantity='y', n_draws=n_draws,
-                                        sample_at_X=XX)
-
-        assert sample_coef.shape == (n_draws, len(mcycle_gam.coef_))
-        assert sample_mu.shape == (n_draws, n_samples_in_grid)
-        assert sample_y.shape == (n_draws, n_samples_in_grid)
-
-    def test_shape_bootstrap_samples_of_smoothing(self, mcycle_X_y, mcycle_gam):
-        X, y = mcycle_X_y
-
-        for n_bootstraps in [1, 2]:
-            coef_bootstraps, cov_bootstraps = (
-                mcycle_gam._bootstrap_samples_of_smoothing(
-                    X, y, n_bootstraps=n_bootstraps))
-            assert len(coef_bootstraps) == len(cov_bootstraps) == n_bootstraps
-            for coef, cov in zip(coef_bootstraps, cov_bootstraps):
-                assert coef.shape == mcycle_gam.coef_.shape
-                assert cov.shape == mcycle_gam.statistics_['cov'].shape
-
-            for n_draws in [1, 2]:
-                coef_draws = mcycle_gam._simulate_coef_from_bootstraps(
-                    n_draws, coef_bootstraps, cov_bootstraps)
-                assert coef_draws.shape == (n_draws, len(mcycle_gam.coef_))
-
-    def test_bad_sample_params(self, mcycle_X_y, mcycle_gam):
-        X, y = mcycle_X_y
-        with pytest.raises(ValueError):
-            mcycle_gam.sample(X, y, n_draws=0)
-        with pytest.raises(ValueError):
-            mcycle_gam.sample(X, y, n_bootstraps=0)
-
-
-def test_prediction_interval_unknown_scale():
-    """
-    the prediction intervals should be correct to a few decimal places
-    we test at a large sample limit, where the t distribution becomes normal
-    """
-    n = 1000000
-    X = np.linspace(0,1,n)
-    y = np.random.randn(n)
-
-    gam_a = LinearGAM(fit_linear=True, fit_splines=False).fit(X, y)
-    gam_b = LinearGAM(n_splines=4).fit(X, y)
-
-    XX = generate_X_grid(gam_a)
-    intervals_a = gam_a.prediction_intervals(XX, quantiles=[0.1, .9]).mean(axis=0)
-    intervals_b = gam_b.prediction_intervals(XX, quantiles=[0.1, .9]).mean(axis=0)
-
-    assert np.allclose(intervals_a[0], sp.stats.norm.ppf(0.1), atol=0.01)
-    assert np.allclose(intervals_a[1], sp.stats.norm.ppf(0.9), atol=0.01)
-
-    assert np.allclose(intervals_b[0], sp.stats.norm.ppf(0.1), atol=0.01)
-    assert np.allclose(intervals_b[1], sp.stats.norm.ppf(0.9), atol=0.01)
-
-def test_prediction_interval_known_scale():
-    """
-    the prediction intervals should be correct to a few decimal places
-    we test at a large sample limit.
-    """
-    n = 1000000
-    X = np.linspace(0,1,n)
-    y = np.random.randn(n)
-
-    gam_a = LinearGAM(fit_linear=True, fit_splines=False, scale=1.).fit(X, y)
-    gam_b = LinearGAM(n_splines=4, scale=1.).fit(X, y)
-
-    XX = generate_X_grid(gam_a)
-    intervals_a = gam_a.prediction_intervals(XX, quantiles=[0.1, .9]).mean(axis=0)
-    intervals_b = gam_b.prediction_intervals(XX, quantiles=[0.1, .9]).mean(axis=0)
-
-    assert np.allclose(intervals_a[0], sp.stats.norm.ppf(0.1), atol=0.01)
-    assert np.allclose(intervals_a[1], sp.stats.norm.ppf(0.9), atol=0.01)
-
-    assert np.allclose(intervals_b[0], sp.stats.norm.ppf(0.1), atol=0.01)
-    assert np.allclose(intervals_b[1], sp.stats.norm.ppf(0.9), atol=0.01)
-
-def test_pvalue_rejects_useless_feature(wage_X_y):
-    """
-    check that a p-value can reject a useless feature
-    """
-    X, y = wage_X_y
-
-    # add empty feature
-    X = np.c_[X, np.zeros(X.shape[0])]
-    gam = LinearGAM().fit(X, y)
-
-    # now do the test, with some safety
-    p_values = gam._estimate_p_values()
-    assert(p_values[-1] > .9)
-
-def test_pvalue_invariant_to_scale(wage_X_y):
+# def test_LinearGAM_pdeps_shape(wage_X_y):
+#     """
+#     check that we get the expected number of partial dependence functions
+#     """
+#     X, y = wage_X_y
+#     gam = LinearGAM().fit(X, y)
+#     pdeps = gam.partial_dependence(X)
+#     assert(X.shape == pdeps.shape)
+#
+# def test_LinearGAM_prediction(mcycle_X_y, mcycle_gam):
+#     """
+#     check that we the predictions we get are correct shape
+#     """
+#     X, y = mcycle_X_y
+#     preds = mcycle_gam.predict(X)
+#     assert(preds.shape == y.shape)
+#
+# def test_LogisticGAM_accuracy(default_X_y):
+#     """
+#     check that we can compute accuracy correctly
+#     """
+#     X, y = default_X_y
+#     gam = LogisticGAM().fit(X, y)
+#
+#     preds = gam.predict(X)
+#     acc0 = (preds == y).mean()
+#     acc1 = gam.accuracy(X, y)
+#     assert(acc0 == acc1)
+#
+# def test_PoissonGAM_exposure(coal_X_y):
+#     """
+#     check that we can fit a Poisson GAM with exposure, and it scales predictions
+#     """
+#     X, y = coal_X_y
+#     gam = PoissonGAM().fit(X, y, exposure=np.ones_like(y))
+#     assert((gam.predict(X, exposure=np.ones_like(y)*2) == 2 *gam.predict(X)).all())
+#
+# def test_PoissonGAM_loglike(coal_X_y):
+#     """
+#     check that our loglikelihood is scaled by exposure
+#
+#     predictions that are twice as large with twice the exposure
+#     should have lower loglikelihood
+#     """
+#     X, y = coal_X_y
+#     exposure = np.ones_like(y)
+#     gam_high_var = PoissonGAM().fit(X, y * 2, exposure=exposure * 2)
+#     gam_low_var = PoissonGAM().fit(X, y, exposure=exposure)
+#
+#     assert gam_high_var.loglikelihood(X, y * 2, exposure * 2) < gam_low_var.loglikelihood(X, y, exposure)
+#
+# def test_large_GAM(coal_X_y):
+#     """
+#     check that we can fit a GAM in py3 when we have more than 50,000 samples
+#     """
+#     X = np.linspace(0, 100, 100000)
+#     y = X**2
+#     gam = LinearGAM().fit(X, y)
+#     assert(gam._is_fitted)
+#
+# def test_summary(mcycle_X_y, mcycle_gam):
+#     """
+#     check that we can get a summary if we've fitted the model, else not
+#     """
+#     X, y = mcycle_X_y
+#     gam = LinearGAM()
+#
+#     try:
+#       gam.summary()
+#     except AttributeError:
+#       assert(True)
+#
+#     mcycle_gam.summary()
+#     assert(True)
+#
+# def test_more_splines_than_samples(mcycle_X_y):
+#     """
+#     check that gridsearch returns the expected number of models
+#     """
+#     X, y = mcycle_X_y
+#     n = len(X)
+#
+#     gam = LinearGAM(n_splines=n+1).fit(X, y)
+#     assert(gam._is_fitted)
+#
+# def test_deviance_residuals(mcycle_X_y, mcycle_gam):
+#     """
+#     for linear GAMs, the deviance residuals should be equal to the y - y_pred
+#     """
+#     X, y = mcycle_X_y
+#     res = mcycle_gam.deviance_residuals(X, y)
+#     err = y - mcycle_gam.predict(X)
+#     assert((res == err).all())
+#
+# def test_conf_intervals_return_array(mcycle_X_y, mcycle_gam):
+#     """
+#     make sure that the confidence_intervals method returns an array
+#     """
+#     X, y = mcycle_X_y
+#     conf_ints = mcycle_gam.confidence_intervals(X)
+#     assert(conf_ints.ndim == 2)
+#
+# def test_conf_intervals_quantiles_width_interchangable(mcycle_X_y, mcycle_gam):
+#     """
+#     getting confidence_intervals via width or specifying quantiles
+#     should return the same result
+#     """
+#     X, y = mcycle_X_y
+#     conf_ints_a = mcycle_gam.confidence_intervals(X, width=.9)
+#     conf_ints_b = mcycle_gam.confidence_intervals(X, quantiles=[.05, .95])
+#     assert(np.allclose(conf_ints_a, conf_ints_b))
+#
+# def test_conf_intervals_ordered(mcycle_X_y, mcycle_gam):
+#     """
+#     comfidence intervals returned via width should be ordered
+#     """
+#     X, y = mcycle_X_y
+#     conf_ints = mcycle_gam.confidence_intervals(X)
+#     assert((conf_ints[:,0] <= conf_ints[:,1]).all())
+#
+# def test_partial_dependence_on_univar_data(mcycle_X_y, mcycle_gam):
+#     """
+#     partial dependence with univariate data should equal the overall model
+#     if fit intercept is false
+#     """
+#     X, y = mcycle_X_y
+#     gam = LinearGAM(fit_intercept=False).fit(X,y)
+#     pred = gam.predict(X)
+#     pdep = gam.partial_dependence(X)
+#     assert((pred == pdep.ravel()).all())
+#
+# def test_partial_dependence_on_univar_data2(mcycle_X_y, mcycle_gam):
+#     """
+#     partial dependence with univariate data should NOT equal the overall model
+#     if fit intercept is false
+#     """
+#     X, y = mcycle_X_y
+#     gam = LinearGAM(fit_intercept=True).fit(X,y)
+#     pred = gam.predict(X)
+#     pdep = gam.partial_dependence(X)
+#     assert((pred != pdep.ravel()).all())
+#
+# def test_partial_dependence_feature_doesnt_exist(mcycle_X_y, mcycle_gam):
+#     """
+#     partial dependence should raise ValueError when requesting a nonexistent
+#     feature
+#     """
+#     X, y = mcycle_X_y
+#     try:
+#         mcycle_gam.partial_dependence(X, feature=10)
+#     except ValueError:
+#         assert(True)
+#
+# def test_summary_returns_12_lines(mcycle_gam):
+#     """
+#     check that the summary method works and returns 24 lines like:
+#
+#     LinearGAM
+#     =============================================== ==========================================================
+#     Distribution:                        NormalDist Effective DoF:                                     11.2495
+#     Link Function:                     IdentityLink Log Likelihood:                                   -952.605
+#     Number of Samples:                          133 AIC:                                             1929.7091
+#                                                     AICc:                                            1932.4197
+#                                                     GCV:                                              605.6546
+#                                                     Scale:                                            514.2013
+#                                                     Pseudo R-Squared:                                   0.7969
+#     ==========================================================================================================
+#     Feature Function   Data Type      Num Splines   Spline Order  Linear Fit  Lambda     P > x      Sig. Code
+#     ================== ============== ============= ============= =========== ========== ========== ==========
+#     feature 1          numerical      25            3             False       1.0        3.43e-03   **
+#     intercept                                                                            6.85e-02   .
+#     ==========================================================================================================
+#     Significance codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
+#
+#     WARNING: Fitting splines and a linear function to a feature introduces a model identifiability problem
+#              which can cause p-values to appear significant when they are not.
+#
+#     WARNING: p-values calculated in this manner behave correctly for un-penalized models or models with
+#              known smoothing parameters, but when smoothing parameters have been estimated, the p-values
+#              are typically lower than they should be, meaning that the tests reject the null too readily.
+#     """
+#     if sys.version_info.major == 2:
+#         from StringIO import StringIO
+#     if sys.version_info.major == 3:
+#         from io import StringIO
+#     stdout = sys.stdout  #keep a handle on the real standard output
+#     sys.stdout = StringIO() #Choose a file-like object to write to
+#     mcycle_gam.summary()
+#     assert(len(sys.stdout.getvalue().split('\n')) == 24)
+#
+# def test_is_fitted_predict(mcycle_X_y):
+#     """
+#     test predict requires fitted model
+#     """
+#     X, y = mcycle_X_y
+#     gam = LinearGAM()
+#     try:
+#         gam.predict(X)
+#     except AttributeError:
+#         assert(True)
+#
+# def test_is_fitted_predict_mu(mcycle_X_y):
+#     """
+#     test predict_mu requires fitted model
+#     """
+#     X, y = mcycle_X_y
+#     gam = LinearGAM()
+#     try:
+#         gam.predict_mu(X)
+#     except AttributeError:
+#         assert(True)
+#
+# def test_is_fitted_dev_resid(mcycle_X_y):
+#     """
+#     test deviance_residuals requires fitted model
+#     """
+#     X, y = mcycle_X_y
+#     gam = LinearGAM()
+#     try:
+#         gam.deviance_residuals(X, y)
+#     except AttributeError:
+#         assert(True)
+#
+# def test_is_fitted_conf_intervals(mcycle_X_y):
+#     """
+#     test confidence_intervals requires fitted model
+#     """
+#     X, y = mcycle_X_y
+#     gam = LinearGAM()
+#     try:
+#         gam.confidence_intervals(X)
+#     except AttributeError:
+#         assert(True)
+#
+#
+# def test_is_fitted_pdep(mcycle_X_y):
+#     """
+#     test partial_dependence requires fitted model
+#     """
+#     X, y = mcycle_X_y
+#     gam = LinearGAM()
+#     try:
+#         gam.partial_dependence(X)
+#     except AttributeError:
+#         assert(True)
+#
+# def test_is_fitted_summary(mcycle_X_y):
+#     """
+#     test summary requires fitted model
+#     """
+#     X, y = mcycle_X_y
+#     gam = LinearGAM()
+#     try:
+#         gam.summary()
+#     except AttributeError:
+#         assert(True)
+#
+# def test_set_params_with_external_param():
+#     """
+#     test set_params sets a real parameter
+#     """
+#     gam = GAM(lam=1)
+#     gam.set_params(lam=420)
+#     assert(gam.lam == 420)
+#
+# def test_set_params_with_hidden_param():
+#     """
+#     test set_params should not set any params that are not exposed to the user
+#     """
+#     gam = GAM()
+#     gam.set_params(_lam=420)
+#     assert(gam._lam != 420)
+#
+# def test_set_params_with_phony_param():
+#     """
+#     test set_params should not set any phony param
+#     """
+#     gam = GAM()
+#     gam.set_params(cat=420)
+#     assert(not hasattr(gam, 'cat'))
+#
+# def test_set_params_with_hidden_param_deep():
+#     """
+#     test set_params can set hidden params if we use the deep=True
+#     """
+#     gam = GAM()
+#     assert(gam._lam != 420)
+#
+#     gam.set_params(_lam=420, deep=True)
+#     assert(gam._lam == 420)
+#
+# def test_set_params_with_phony_param_force():
+#     """
+#     test set_params can set phony params if we use the force=True
+#     """
+#     gam = GAM()
+#     assert(not hasattr(gam, 'cat'))
+#
+#     gam.set_params(cat=420, force=True)
+#     assert(gam.cat == 420)
+#
+# def test_get_params():
+#     """
+#     test gam gets our params
+#     """
+#     gam = GAM(lam=420)
+#     params = gam.get_params()
+#     assert(params['lam'] == 420)
+#
+# def test_get_params_hidden():
+#     """
+#     test gam gets our params only if we do deep=True
+#     """
+#     gam = GAM()
+#     params = gam.get_params()
+#     assert('_lam' not in list(params.keys()))
+#
+#     params = gam.get_params(deep=True)
+#     assert('_lam' in list(params.keys()))
+#
+#
+# class TestSamplingFromPosterior(object):
+#
+#     def test_drawing_samples_from_unfitted_model(self, mcycle_X_y, mcycle_gam):
+#         X, y = mcycle_X_y
+#         gam = LinearGAM()
+#
+#         with pytest.raises(AttributeError):
+#             gam.sample(X, y)
+#
+#         with pytest.raises(AttributeError):
+#             gam._sample_coef(X, y)
+#
+#         with pytest.raises(AttributeError):
+#             gam._bootstrap_samples_of_smoothing(X, y)
+#
+#         assert mcycle_gam._is_fitted
+#
+#         mcycle_gam.sample(X, y, n_draws=2)
+#         mcycle_gam._sample_coef(X, y, n_draws=2)
+#         mcycle_gam._bootstrap_samples_of_smoothing(X, y, n_bootstraps=1)
+#         assert True
+#
+#     def test_sample_quantity(self, mcycle_X_y, mcycle_gam):
+#         X, y = mcycle_X_y
+#         for quantity in ['coefficients', 'response']:
+#             with pytest.raises(ValueError):
+#                 mcycle_gam.sample(X, y, quantity=quantity, n_draws=2)
+#         for quantity in ['coef', 'mu', 'y']:
+#             mcycle_gam.sample(X, y, quantity=quantity, n_draws=2)
+#             assert True
+#
+#     def test_shape_of_random_samples(self, mcycle_X_y, mcycle_gam):
+#         X, y = mcycle_X_y
+#         n_samples = len(X)
+#         n_draws = 5
+#
+#         sample_coef = mcycle_gam.sample(X, y, quantity='coef', n_draws=n_draws)
+#         sample_mu = mcycle_gam.sample(X, y, quantity='mu', n_draws=n_draws)
+#         sample_y = mcycle_gam.sample(X, y, quantity='y', n_draws=n_draws)
+#         assert sample_coef.shape == (n_draws, len(mcycle_gam.coef_))
+#         assert sample_mu.shape == (n_draws, n_samples)
+#         assert sample_y.shape == (n_draws, n_samples)
+#
+#         XX = generate_X_grid(mcycle_gam)
+#         n_samples_in_grid = len(XX)
+#         sample_coef = mcycle_gam.sample(X, y, quantity='coef', n_draws=n_draws,
+#                                         sample_at_X=XX)
+#         sample_mu = mcycle_gam.sample(X, y, quantity='mu', n_draws=n_draws,
+#                                         sample_at_X=XX)
+#         sample_y = mcycle_gam.sample(X, y, quantity='y', n_draws=n_draws,
+#                                         sample_at_X=XX)
+#
+#         assert sample_coef.shape == (n_draws, len(mcycle_gam.coef_))
+#         assert sample_mu.shape == (n_draws, n_samples_in_grid)
+#         assert sample_y.shape == (n_draws, n_samples_in_grid)
+#
+#     def test_shape_bootstrap_samples_of_smoothing(self, mcycle_X_y, mcycle_gam):
+#         X, y = mcycle_X_y
+#
+#         for n_bootstraps in [1, 2]:
+#             coef_bootstraps, cov_bootstraps = (
+#                 mcycle_gam._bootstrap_samples_of_smoothing(
+#                     X, y, n_bootstraps=n_bootstraps))
+#             assert len(coef_bootstraps) == len(cov_bootstraps) == n_bootstraps
+#             for coef, cov in zip(coef_bootstraps, cov_bootstraps):
+#                 assert coef.shape == mcycle_gam.coef_.shape
+#                 assert cov.shape == mcycle_gam.statistics_['cov'].shape
+#
+#             for n_draws in [1, 2]:
+#                 coef_draws = mcycle_gam._simulate_coef_from_bootstraps(
+#                     n_draws, coef_bootstraps, cov_bootstraps)
+#                 assert coef_draws.shape == (n_draws, len(mcycle_gam.coef_))
+#
+#     def test_bad_sample_params(self, mcycle_X_y, mcycle_gam):
+#         X, y = mcycle_X_y
+#         with pytest.raises(ValueError):
+#             mcycle_gam.sample(X, y, n_draws=0)
+#         with pytest.raises(ValueError):
+#             mcycle_gam.sample(X, y, n_bootstraps=0)
+#
+#
+# def test_prediction_interval_unknown_scale():
+#     """
+#     the prediction intervals should be correct to a few decimal places
+#     we test at a large sample limit, where the t distribution becomes normal
+#     """
+#     n = 1000000
+#     X = np.linspace(0,1,n)
+#     y = np.random.randn(n)
+#
+#     gam_a = LinearGAM(fit_linear=True, fit_splines=False).fit(X, y)
+#     gam_b = LinearGAM(n_splines=4).fit(X, y)
+#
+#     XX = generate_X_grid(gam_a)
+#     intervals_a = gam_a.prediction_intervals(XX, quantiles=[0.1, .9]).mean(axis=0)
+#     intervals_b = gam_b.prediction_intervals(XX, quantiles=[0.1, .9]).mean(axis=0)
+#
+#     assert np.allclose(intervals_a[0], sp.stats.norm.ppf(0.1), atol=0.01)
+#     assert np.allclose(intervals_a[1], sp.stats.norm.ppf(0.9), atol=0.01)
+#
+#     assert np.allclose(intervals_b[0], sp.stats.norm.ppf(0.1), atol=0.01)
+#     assert np.allclose(intervals_b[1], sp.stats.norm.ppf(0.9), atol=0.01)
+#
+# def test_prediction_interval_known_scale():
+#     """
+#     the prediction intervals should be correct to a few decimal places
+#     we test at a large sample limit.
+#     """
+#     n = 1000000
+#     X = np.linspace(0,1,n)
+#     y = np.random.randn(n)
+#
+#     gam_a = LinearGAM(fit_linear=True, fit_splines=False, scale=1.).fit(X, y)
+#     gam_b = LinearGAM(n_splines=4, scale=1.).fit(X, y)
+#
+#     XX = generate_X_grid(gam_a)
+#     intervals_a = gam_a.prediction_intervals(XX, quantiles=[0.1, .9]).mean(axis=0)
+#     intervals_b = gam_b.prediction_intervals(XX, quantiles=[0.1, .9]).mean(axis=0)
+#
+#     assert np.allclose(intervals_a[0], sp.stats.norm.ppf(0.1), atol=0.01)
+#     assert np.allclose(intervals_a[1], sp.stats.norm.ppf(0.9), atol=0.01)
+#
+#     assert np.allclose(intervals_b[0], sp.stats.norm.ppf(0.1), atol=0.01)
+#     assert np.allclose(intervals_b[1], sp.stats.norm.ppf(0.9), atol=0.01)
+#
+# def test_pvalue_rejects_useless_feature(wage_X_y):
+#     """
+#     check that a p-value can reject a useless feature
+#     """
+#     X, y = wage_X_y
+#
+#     # add empty feature
+#     X = np.c_[X, np.zeros(X.shape[0])]
+#     gam = LinearGAM().fit(X, y)
+#
+#     # now do the test, with some safety
+#     p_values = gam._estimate_p_values()
+#     assert(p_values[-1] > .9)
+#
+# def test_pvalue_invariant_to_scale(wage_X_y):
+#     """
+#     regression test.
+#
+#     a bug made the F-statistic sensitive to scale changes, when it should be invariant.
+#
+#     check that a p-value should not change when we change the scale of the response
+#     """
+#     X, y = wage_X_y
+#
+#     gamA = LinearGAM(n_splines=10).fit(X, y * 1000000)
+#     gamB = LinearGAM(n_splines=10).fit(X, y)
+#
+#     assert np.allclose(gamA.statistics_['p_values'], gamB.statistics_['p_values'])
+#
+
+def test_2d_y_still_allow_fitting_in_PoissonGAM(coal_X_y):
     """
     regression test.
 
-    a bug made the F-statistic sensitive to scale changes, when it should be invariant.
-
-    check that a p-value should not change when we change the scale of the response
+    there was a bug where we forgot to check the y_array before converting
+    exposure to weights.
     """
-    X, y = wage_X_y
+    X, y = coal_X_y
+    two_d_data = np.ones_like(y).ravel()[:, None]
 
-    gamA = LinearGAM(n_splines=10).fit(X, y * 1000000)
-    gamB = LinearGAM(n_splines=10).fit(X, y)
+    # 2d y should cause no problems now
+    gam = PoissonGAM().fit(X, y[:, None])
+    assert gam._is_fitted
 
-    assert np.allclose(gamA.statistics_['p_values'], gamB.statistics_['p_values'])
+    # 2d weghts should cause no problems now
+    gam = PoissonGAM().fit(X, y, weights=two_d_data)
+    assert gam._is_fitted
+
+    # 2d exposure should cause no problems now
+    gam = PoissonGAM().fit(X, y, exposure=two_d_data)
+    assert gam._is_fitted

--- a/pygam/tests/test_GAM_methods.py
+++ b/pygam/tests/test_GAM_methods.py
@@ -16,481 +16,481 @@ def mcycle_gam(mcycle_X_y):
     gam = LinearGAM().fit(X,y)
     return gam
 
-# def test_LinearGAM_pdeps_shape(wage_X_y):
-#     """
-#     check that we get the expected number of partial dependence functions
-#     """
-#     X, y = wage_X_y
-#     gam = LinearGAM().fit(X, y)
-#     pdeps = gam.partial_dependence(X)
-#     assert(X.shape == pdeps.shape)
-#
-# def test_LinearGAM_prediction(mcycle_X_y, mcycle_gam):
-#     """
-#     check that we the predictions we get are correct shape
-#     """
-#     X, y = mcycle_X_y
-#     preds = mcycle_gam.predict(X)
-#     assert(preds.shape == y.shape)
-#
-# def test_LogisticGAM_accuracy(default_X_y):
-#     """
-#     check that we can compute accuracy correctly
-#     """
-#     X, y = default_X_y
-#     gam = LogisticGAM().fit(X, y)
-#
-#     preds = gam.predict(X)
-#     acc0 = (preds == y).mean()
-#     acc1 = gam.accuracy(X, y)
-#     assert(acc0 == acc1)
-#
-# def test_PoissonGAM_exposure(coal_X_y):
-#     """
-#     check that we can fit a Poisson GAM with exposure, and it scales predictions
-#     """
-#     X, y = coal_X_y
-#     gam = PoissonGAM().fit(X, y, exposure=np.ones_like(y))
-#     assert((gam.predict(X, exposure=np.ones_like(y)*2) == 2 *gam.predict(X)).all())
-#
-# def test_PoissonGAM_loglike(coal_X_y):
-#     """
-#     check that our loglikelihood is scaled by exposure
-#
-#     predictions that are twice as large with twice the exposure
-#     should have lower loglikelihood
-#     """
-#     X, y = coal_X_y
-#     exposure = np.ones_like(y)
-#     gam_high_var = PoissonGAM().fit(X, y * 2, exposure=exposure * 2)
-#     gam_low_var = PoissonGAM().fit(X, y, exposure=exposure)
-#
-#     assert gam_high_var.loglikelihood(X, y * 2, exposure * 2) < gam_low_var.loglikelihood(X, y, exposure)
-#
-# def test_large_GAM(coal_X_y):
-#     """
-#     check that we can fit a GAM in py3 when we have more than 50,000 samples
-#     """
-#     X = np.linspace(0, 100, 100000)
-#     y = X**2
-#     gam = LinearGAM().fit(X, y)
-#     assert(gam._is_fitted)
-#
-# def test_summary(mcycle_X_y, mcycle_gam):
-#     """
-#     check that we can get a summary if we've fitted the model, else not
-#     """
-#     X, y = mcycle_X_y
-#     gam = LinearGAM()
-#
-#     try:
-#       gam.summary()
-#     except AttributeError:
-#       assert(True)
-#
-#     mcycle_gam.summary()
-#     assert(True)
-#
-# def test_more_splines_than_samples(mcycle_X_y):
-#     """
-#     check that gridsearch returns the expected number of models
-#     """
-#     X, y = mcycle_X_y
-#     n = len(X)
-#
-#     gam = LinearGAM(n_splines=n+1).fit(X, y)
-#     assert(gam._is_fitted)
-#
-# def test_deviance_residuals(mcycle_X_y, mcycle_gam):
-#     """
-#     for linear GAMs, the deviance residuals should be equal to the y - y_pred
-#     """
-#     X, y = mcycle_X_y
-#     res = mcycle_gam.deviance_residuals(X, y)
-#     err = y - mcycle_gam.predict(X)
-#     assert((res == err).all())
-#
-# def test_conf_intervals_return_array(mcycle_X_y, mcycle_gam):
-#     """
-#     make sure that the confidence_intervals method returns an array
-#     """
-#     X, y = mcycle_X_y
-#     conf_ints = mcycle_gam.confidence_intervals(X)
-#     assert(conf_ints.ndim == 2)
-#
-# def test_conf_intervals_quantiles_width_interchangable(mcycle_X_y, mcycle_gam):
-#     """
-#     getting confidence_intervals via width or specifying quantiles
-#     should return the same result
-#     """
-#     X, y = mcycle_X_y
-#     conf_ints_a = mcycle_gam.confidence_intervals(X, width=.9)
-#     conf_ints_b = mcycle_gam.confidence_intervals(X, quantiles=[.05, .95])
-#     assert(np.allclose(conf_ints_a, conf_ints_b))
-#
-# def test_conf_intervals_ordered(mcycle_X_y, mcycle_gam):
-#     """
-#     comfidence intervals returned via width should be ordered
-#     """
-#     X, y = mcycle_X_y
-#     conf_ints = mcycle_gam.confidence_intervals(X)
-#     assert((conf_ints[:,0] <= conf_ints[:,1]).all())
-#
-# def test_partial_dependence_on_univar_data(mcycle_X_y, mcycle_gam):
-#     """
-#     partial dependence with univariate data should equal the overall model
-#     if fit intercept is false
-#     """
-#     X, y = mcycle_X_y
-#     gam = LinearGAM(fit_intercept=False).fit(X,y)
-#     pred = gam.predict(X)
-#     pdep = gam.partial_dependence(X)
-#     assert((pred == pdep.ravel()).all())
-#
-# def test_partial_dependence_on_univar_data2(mcycle_X_y, mcycle_gam):
-#     """
-#     partial dependence with univariate data should NOT equal the overall model
-#     if fit intercept is false
-#     """
-#     X, y = mcycle_X_y
-#     gam = LinearGAM(fit_intercept=True).fit(X,y)
-#     pred = gam.predict(X)
-#     pdep = gam.partial_dependence(X)
-#     assert((pred != pdep.ravel()).all())
-#
-# def test_partial_dependence_feature_doesnt_exist(mcycle_X_y, mcycle_gam):
-#     """
-#     partial dependence should raise ValueError when requesting a nonexistent
-#     feature
-#     """
-#     X, y = mcycle_X_y
-#     try:
-#         mcycle_gam.partial_dependence(X, feature=10)
-#     except ValueError:
-#         assert(True)
-#
-# def test_summary_returns_12_lines(mcycle_gam):
-#     """
-#     check that the summary method works and returns 24 lines like:
-#
-#     LinearGAM
-#     =============================================== ==========================================================
-#     Distribution:                        NormalDist Effective DoF:                                     11.2495
-#     Link Function:                     IdentityLink Log Likelihood:                                   -952.605
-#     Number of Samples:                          133 AIC:                                             1929.7091
-#                                                     AICc:                                            1932.4197
-#                                                     GCV:                                              605.6546
-#                                                     Scale:                                            514.2013
-#                                                     Pseudo R-Squared:                                   0.7969
-#     ==========================================================================================================
-#     Feature Function   Data Type      Num Splines   Spline Order  Linear Fit  Lambda     P > x      Sig. Code
-#     ================== ============== ============= ============= =========== ========== ========== ==========
-#     feature 1          numerical      25            3             False       1.0        3.43e-03   **
-#     intercept                                                                            6.85e-02   .
-#     ==========================================================================================================
-#     Significance codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
-#
-#     WARNING: Fitting splines and a linear function to a feature introduces a model identifiability problem
-#              which can cause p-values to appear significant when they are not.
-#
-#     WARNING: p-values calculated in this manner behave correctly for un-penalized models or models with
-#              known smoothing parameters, but when smoothing parameters have been estimated, the p-values
-#              are typically lower than they should be, meaning that the tests reject the null too readily.
-#     """
-#     if sys.version_info.major == 2:
-#         from StringIO import StringIO
-#     if sys.version_info.major == 3:
-#         from io import StringIO
-#     stdout = sys.stdout  #keep a handle on the real standard output
-#     sys.stdout = StringIO() #Choose a file-like object to write to
-#     mcycle_gam.summary()
-#     assert(len(sys.stdout.getvalue().split('\n')) == 24)
-#
-# def test_is_fitted_predict(mcycle_X_y):
-#     """
-#     test predict requires fitted model
-#     """
-#     X, y = mcycle_X_y
-#     gam = LinearGAM()
-#     try:
-#         gam.predict(X)
-#     except AttributeError:
-#         assert(True)
-#
-# def test_is_fitted_predict_mu(mcycle_X_y):
-#     """
-#     test predict_mu requires fitted model
-#     """
-#     X, y = mcycle_X_y
-#     gam = LinearGAM()
-#     try:
-#         gam.predict_mu(X)
-#     except AttributeError:
-#         assert(True)
-#
-# def test_is_fitted_dev_resid(mcycle_X_y):
-#     """
-#     test deviance_residuals requires fitted model
-#     """
-#     X, y = mcycle_X_y
-#     gam = LinearGAM()
-#     try:
-#         gam.deviance_residuals(X, y)
-#     except AttributeError:
-#         assert(True)
-#
-# def test_is_fitted_conf_intervals(mcycle_X_y):
-#     """
-#     test confidence_intervals requires fitted model
-#     """
-#     X, y = mcycle_X_y
-#     gam = LinearGAM()
-#     try:
-#         gam.confidence_intervals(X)
-#     except AttributeError:
-#         assert(True)
-#
-#
-# def test_is_fitted_pdep(mcycle_X_y):
-#     """
-#     test partial_dependence requires fitted model
-#     """
-#     X, y = mcycle_X_y
-#     gam = LinearGAM()
-#     try:
-#         gam.partial_dependence(X)
-#     except AttributeError:
-#         assert(True)
-#
-# def test_is_fitted_summary(mcycle_X_y):
-#     """
-#     test summary requires fitted model
-#     """
-#     X, y = mcycle_X_y
-#     gam = LinearGAM()
-#     try:
-#         gam.summary()
-#     except AttributeError:
-#         assert(True)
-#
-# def test_set_params_with_external_param():
-#     """
-#     test set_params sets a real parameter
-#     """
-#     gam = GAM(lam=1)
-#     gam.set_params(lam=420)
-#     assert(gam.lam == 420)
-#
-# def test_set_params_with_hidden_param():
-#     """
-#     test set_params should not set any params that are not exposed to the user
-#     """
-#     gam = GAM()
-#     gam.set_params(_lam=420)
-#     assert(gam._lam != 420)
-#
-# def test_set_params_with_phony_param():
-#     """
-#     test set_params should not set any phony param
-#     """
-#     gam = GAM()
-#     gam.set_params(cat=420)
-#     assert(not hasattr(gam, 'cat'))
-#
-# def test_set_params_with_hidden_param_deep():
-#     """
-#     test set_params can set hidden params if we use the deep=True
-#     """
-#     gam = GAM()
-#     assert(gam._lam != 420)
-#
-#     gam.set_params(_lam=420, deep=True)
-#     assert(gam._lam == 420)
-#
-# def test_set_params_with_phony_param_force():
-#     """
-#     test set_params can set phony params if we use the force=True
-#     """
-#     gam = GAM()
-#     assert(not hasattr(gam, 'cat'))
-#
-#     gam.set_params(cat=420, force=True)
-#     assert(gam.cat == 420)
-#
-# def test_get_params():
-#     """
-#     test gam gets our params
-#     """
-#     gam = GAM(lam=420)
-#     params = gam.get_params()
-#     assert(params['lam'] == 420)
-#
-# def test_get_params_hidden():
-#     """
-#     test gam gets our params only if we do deep=True
-#     """
-#     gam = GAM()
-#     params = gam.get_params()
-#     assert('_lam' not in list(params.keys()))
-#
-#     params = gam.get_params(deep=True)
-#     assert('_lam' in list(params.keys()))
-#
-#
-# class TestSamplingFromPosterior(object):
-#
-#     def test_drawing_samples_from_unfitted_model(self, mcycle_X_y, mcycle_gam):
-#         X, y = mcycle_X_y
-#         gam = LinearGAM()
-#
-#         with pytest.raises(AttributeError):
-#             gam.sample(X, y)
-#
-#         with pytest.raises(AttributeError):
-#             gam._sample_coef(X, y)
-#
-#         with pytest.raises(AttributeError):
-#             gam._bootstrap_samples_of_smoothing(X, y)
-#
-#         assert mcycle_gam._is_fitted
-#
-#         mcycle_gam.sample(X, y, n_draws=2)
-#         mcycle_gam._sample_coef(X, y, n_draws=2)
-#         mcycle_gam._bootstrap_samples_of_smoothing(X, y, n_bootstraps=1)
-#         assert True
-#
-#     def test_sample_quantity(self, mcycle_X_y, mcycle_gam):
-#         X, y = mcycle_X_y
-#         for quantity in ['coefficients', 'response']:
-#             with pytest.raises(ValueError):
-#                 mcycle_gam.sample(X, y, quantity=quantity, n_draws=2)
-#         for quantity in ['coef', 'mu', 'y']:
-#             mcycle_gam.sample(X, y, quantity=quantity, n_draws=2)
-#             assert True
-#
-#     def test_shape_of_random_samples(self, mcycle_X_y, mcycle_gam):
-#         X, y = mcycle_X_y
-#         n_samples = len(X)
-#         n_draws = 5
-#
-#         sample_coef = mcycle_gam.sample(X, y, quantity='coef', n_draws=n_draws)
-#         sample_mu = mcycle_gam.sample(X, y, quantity='mu', n_draws=n_draws)
-#         sample_y = mcycle_gam.sample(X, y, quantity='y', n_draws=n_draws)
-#         assert sample_coef.shape == (n_draws, len(mcycle_gam.coef_))
-#         assert sample_mu.shape == (n_draws, n_samples)
-#         assert sample_y.shape == (n_draws, n_samples)
-#
-#         XX = generate_X_grid(mcycle_gam)
-#         n_samples_in_grid = len(XX)
-#         sample_coef = mcycle_gam.sample(X, y, quantity='coef', n_draws=n_draws,
-#                                         sample_at_X=XX)
-#         sample_mu = mcycle_gam.sample(X, y, quantity='mu', n_draws=n_draws,
-#                                         sample_at_X=XX)
-#         sample_y = mcycle_gam.sample(X, y, quantity='y', n_draws=n_draws,
-#                                         sample_at_X=XX)
-#
-#         assert sample_coef.shape == (n_draws, len(mcycle_gam.coef_))
-#         assert sample_mu.shape == (n_draws, n_samples_in_grid)
-#         assert sample_y.shape == (n_draws, n_samples_in_grid)
-#
-#     def test_shape_bootstrap_samples_of_smoothing(self, mcycle_X_y, mcycle_gam):
-#         X, y = mcycle_X_y
-#
-#         for n_bootstraps in [1, 2]:
-#             coef_bootstraps, cov_bootstraps = (
-#                 mcycle_gam._bootstrap_samples_of_smoothing(
-#                     X, y, n_bootstraps=n_bootstraps))
-#             assert len(coef_bootstraps) == len(cov_bootstraps) == n_bootstraps
-#             for coef, cov in zip(coef_bootstraps, cov_bootstraps):
-#                 assert coef.shape == mcycle_gam.coef_.shape
-#                 assert cov.shape == mcycle_gam.statistics_['cov'].shape
-#
-#             for n_draws in [1, 2]:
-#                 coef_draws = mcycle_gam._simulate_coef_from_bootstraps(
-#                     n_draws, coef_bootstraps, cov_bootstraps)
-#                 assert coef_draws.shape == (n_draws, len(mcycle_gam.coef_))
-#
-#     def test_bad_sample_params(self, mcycle_X_y, mcycle_gam):
-#         X, y = mcycle_X_y
-#         with pytest.raises(ValueError):
-#             mcycle_gam.sample(X, y, n_draws=0)
-#         with pytest.raises(ValueError):
-#             mcycle_gam.sample(X, y, n_bootstraps=0)
-#
-#
-# def test_prediction_interval_unknown_scale():
-#     """
-#     the prediction intervals should be correct to a few decimal places
-#     we test at a large sample limit, where the t distribution becomes normal
-#     """
-#     n = 1000000
-#     X = np.linspace(0,1,n)
-#     y = np.random.randn(n)
-#
-#     gam_a = LinearGAM(fit_linear=True, fit_splines=False).fit(X, y)
-#     gam_b = LinearGAM(n_splines=4).fit(X, y)
-#
-#     XX = generate_X_grid(gam_a)
-#     intervals_a = gam_a.prediction_intervals(XX, quantiles=[0.1, .9]).mean(axis=0)
-#     intervals_b = gam_b.prediction_intervals(XX, quantiles=[0.1, .9]).mean(axis=0)
-#
-#     assert np.allclose(intervals_a[0], sp.stats.norm.ppf(0.1), atol=0.01)
-#     assert np.allclose(intervals_a[1], sp.stats.norm.ppf(0.9), atol=0.01)
-#
-#     assert np.allclose(intervals_b[0], sp.stats.norm.ppf(0.1), atol=0.01)
-#     assert np.allclose(intervals_b[1], sp.stats.norm.ppf(0.9), atol=0.01)
-#
-# def test_prediction_interval_known_scale():
-#     """
-#     the prediction intervals should be correct to a few decimal places
-#     we test at a large sample limit.
-#     """
-#     n = 1000000
-#     X = np.linspace(0,1,n)
-#     y = np.random.randn(n)
-#
-#     gam_a = LinearGAM(fit_linear=True, fit_splines=False, scale=1.).fit(X, y)
-#     gam_b = LinearGAM(n_splines=4, scale=1.).fit(X, y)
-#
-#     XX = generate_X_grid(gam_a)
-#     intervals_a = gam_a.prediction_intervals(XX, quantiles=[0.1, .9]).mean(axis=0)
-#     intervals_b = gam_b.prediction_intervals(XX, quantiles=[0.1, .9]).mean(axis=0)
-#
-#     assert np.allclose(intervals_a[0], sp.stats.norm.ppf(0.1), atol=0.01)
-#     assert np.allclose(intervals_a[1], sp.stats.norm.ppf(0.9), atol=0.01)
-#
-#     assert np.allclose(intervals_b[0], sp.stats.norm.ppf(0.1), atol=0.01)
-#     assert np.allclose(intervals_b[1], sp.stats.norm.ppf(0.9), atol=0.01)
-#
-# def test_pvalue_rejects_useless_feature(wage_X_y):
-#     """
-#     check that a p-value can reject a useless feature
-#     """
-#     X, y = wage_X_y
-#
-#     # add empty feature
-#     X = np.c_[X, np.zeros(X.shape[0])]
-#     gam = LinearGAM().fit(X, y)
-#
-#     # now do the test, with some safety
-#     p_values = gam._estimate_p_values()
-#     assert(p_values[-1] > .9)
-#
-# def test_pvalue_invariant_to_scale(wage_X_y):
-#     """
-#     regression test.
-#
-#     a bug made the F-statistic sensitive to scale changes, when it should be invariant.
-#
-#     check that a p-value should not change when we change the scale of the response
-#     """
-#     X, y = wage_X_y
-#
-#     gamA = LinearGAM(n_splines=10).fit(X, y * 1000000)
-#     gamB = LinearGAM(n_splines=10).fit(X, y)
-#
-#     assert np.allclose(gamA.statistics_['p_values'], gamB.statistics_['p_values'])
-#
+def test_LinearGAM_pdeps_shape(wage_X_y):
+    """
+    check that we get the expected number of partial dependence functions
+    """
+    X, y = wage_X_y
+    gam = LinearGAM().fit(X, y)
+    pdeps = gam.partial_dependence(X)
+    assert(X.shape == pdeps.shape)
+
+def test_LinearGAM_prediction(mcycle_X_y, mcycle_gam):
+    """
+    check that we the predictions we get are correct shape
+    """
+    X, y = mcycle_X_y
+    preds = mcycle_gam.predict(X)
+    assert(preds.shape == y.shape)
+
+def test_LogisticGAM_accuracy(default_X_y):
+    """
+    check that we can compute accuracy correctly
+    """
+    X, y = default_X_y
+    gam = LogisticGAM().fit(X, y)
+
+    preds = gam.predict(X)
+    acc0 = (preds == y).mean()
+    acc1 = gam.accuracy(X, y)
+    assert(acc0 == acc1)
+
+def test_PoissonGAM_exposure(coal_X_y):
+    """
+    check that we can fit a Poisson GAM with exposure, and it scales predictions
+    """
+    X, y = coal_X_y
+    gam = PoissonGAM().fit(X, y, exposure=np.ones_like(y))
+    assert((gam.predict(X, exposure=np.ones_like(y)*2) == 2 *gam.predict(X)).all())
+
+def test_PoissonGAM_loglike(coal_X_y):
+    """
+    check that our loglikelihood is scaled by exposure
+
+    predictions that are twice as large with twice the exposure
+    should have lower loglikelihood
+    """
+    X, y = coal_X_y
+    exposure = np.ones_like(y)
+    gam_high_var = PoissonGAM().fit(X, y * 2, exposure=exposure * 2)
+    gam_low_var = PoissonGAM().fit(X, y, exposure=exposure)
+
+    assert gam_high_var.loglikelihood(X, y * 2, exposure * 2) < gam_low_var.loglikelihood(X, y, exposure)
+
+def test_large_GAM(coal_X_y):
+    """
+    check that we can fit a GAM in py3 when we have more than 50,000 samples
+    """
+    X = np.linspace(0, 100, 100000)
+    y = X**2
+    gam = LinearGAM().fit(X, y)
+    assert(gam._is_fitted)
+
+def test_summary(mcycle_X_y, mcycle_gam):
+    """
+    check that we can get a summary if we've fitted the model, else not
+    """
+    X, y = mcycle_X_y
+    gam = LinearGAM()
+
+    try:
+      gam.summary()
+    except AttributeError:
+      assert(True)
+
+    mcycle_gam.summary()
+    assert(True)
+
+def test_more_splines_than_samples(mcycle_X_y):
+    """
+    check that gridsearch returns the expected number of models
+    """
+    X, y = mcycle_X_y
+    n = len(X)
+
+    gam = LinearGAM(n_splines=n+1).fit(X, y)
+    assert(gam._is_fitted)
+
+def test_deviance_residuals(mcycle_X_y, mcycle_gam):
+    """
+    for linear GAMs, the deviance residuals should be equal to the y - y_pred
+    """
+    X, y = mcycle_X_y
+    res = mcycle_gam.deviance_residuals(X, y)
+    err = y - mcycle_gam.predict(X)
+    assert((res == err).all())
+
+def test_conf_intervals_return_array(mcycle_X_y, mcycle_gam):
+    """
+    make sure that the confidence_intervals method returns an array
+    """
+    X, y = mcycle_X_y
+    conf_ints = mcycle_gam.confidence_intervals(X)
+    assert(conf_ints.ndim == 2)
+
+def test_conf_intervals_quantiles_width_interchangable(mcycle_X_y, mcycle_gam):
+    """
+    getting confidence_intervals via width or specifying quantiles
+    should return the same result
+    """
+    X, y = mcycle_X_y
+    conf_ints_a = mcycle_gam.confidence_intervals(X, width=.9)
+    conf_ints_b = mcycle_gam.confidence_intervals(X, quantiles=[.05, .95])
+    assert(np.allclose(conf_ints_a, conf_ints_b))
+
+def test_conf_intervals_ordered(mcycle_X_y, mcycle_gam):
+    """
+    comfidence intervals returned via width should be ordered
+    """
+    X, y = mcycle_X_y
+    conf_ints = mcycle_gam.confidence_intervals(X)
+    assert((conf_ints[:,0] <= conf_ints[:,1]).all())
+
+def test_partial_dependence_on_univar_data(mcycle_X_y, mcycle_gam):
+    """
+    partial dependence with univariate data should equal the overall model
+    if fit intercept is false
+    """
+    X, y = mcycle_X_y
+    gam = LinearGAM(fit_intercept=False).fit(X,y)
+    pred = gam.predict(X)
+    pdep = gam.partial_dependence(X)
+    assert((pred == pdep.ravel()).all())
+
+def test_partial_dependence_on_univar_data2(mcycle_X_y, mcycle_gam):
+    """
+    partial dependence with univariate data should NOT equal the overall model
+    if fit intercept is false
+    """
+    X, y = mcycle_X_y
+    gam = LinearGAM(fit_intercept=True).fit(X,y)
+    pred = gam.predict(X)
+    pdep = gam.partial_dependence(X)
+    assert((pred != pdep.ravel()).all())
+
+def test_partial_dependence_feature_doesnt_exist(mcycle_X_y, mcycle_gam):
+    """
+    partial dependence should raise ValueError when requesting a nonexistent
+    feature
+    """
+    X, y = mcycle_X_y
+    try:
+        mcycle_gam.partial_dependence(X, feature=10)
+    except ValueError:
+        assert(True)
+
+def test_summary_returns_12_lines(mcycle_gam):
+    """
+    check that the summary method works and returns 24 lines like:
+
+    LinearGAM
+    =============================================== ==========================================================
+    Distribution:                        NormalDist Effective DoF:                                     11.2495
+    Link Function:                     IdentityLink Log Likelihood:                                   -952.605
+    Number of Samples:                          133 AIC:                                             1929.7091
+                                                    AICc:                                            1932.4197
+                                                    GCV:                                              605.6546
+                                                    Scale:                                            514.2013
+                                                    Pseudo R-Squared:                                   0.7969
+    ==========================================================================================================
+    Feature Function   Data Type      Num Splines   Spline Order  Linear Fit  Lambda     P > x      Sig. Code
+    ================== ============== ============= ============= =========== ========== ========== ==========
+    feature 1          numerical      25            3             False       1.0        3.43e-03   **
+    intercept                                                                            6.85e-02   .
+    ==========================================================================================================
+    Significance codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
+
+    WARNING: Fitting splines and a linear function to a feature introduces a model identifiability problem
+             which can cause p-values to appear significant when they are not.
+
+    WARNING: p-values calculated in this manner behave correctly for un-penalized models or models with
+             known smoothing parameters, but when smoothing parameters have been estimated, the p-values
+             are typically lower than they should be, meaning that the tests reject the null too readily.
+    """
+    if sys.version_info.major == 2:
+        from StringIO import StringIO
+    if sys.version_info.major == 3:
+        from io import StringIO
+    stdout = sys.stdout  #keep a handle on the real standard output
+    sys.stdout = StringIO() #Choose a file-like object to write to
+    mcycle_gam.summary()
+    assert(len(sys.stdout.getvalue().split('\n')) == 24)
+
+def test_is_fitted_predict(mcycle_X_y):
+    """
+    test predict requires fitted model
+    """
+    X, y = mcycle_X_y
+    gam = LinearGAM()
+    try:
+        gam.predict(X)
+    except AttributeError:
+        assert(True)
+
+def test_is_fitted_predict_mu(mcycle_X_y):
+    """
+    test predict_mu requires fitted model
+    """
+    X, y = mcycle_X_y
+    gam = LinearGAM()
+    try:
+        gam.predict_mu(X)
+    except AttributeError:
+        assert(True)
+
+def test_is_fitted_dev_resid(mcycle_X_y):
+    """
+    test deviance_residuals requires fitted model
+    """
+    X, y = mcycle_X_y
+    gam = LinearGAM()
+    try:
+        gam.deviance_residuals(X, y)
+    except AttributeError:
+        assert(True)
+
+def test_is_fitted_conf_intervals(mcycle_X_y):
+    """
+    test confidence_intervals requires fitted model
+    """
+    X, y = mcycle_X_y
+    gam = LinearGAM()
+    try:
+        gam.confidence_intervals(X)
+    except AttributeError:
+        assert(True)
+
+
+def test_is_fitted_pdep(mcycle_X_y):
+    """
+    test partial_dependence requires fitted model
+    """
+    X, y = mcycle_X_y
+    gam = LinearGAM()
+    try:
+        gam.partial_dependence(X)
+    except AttributeError:
+        assert(True)
+
+def test_is_fitted_summary(mcycle_X_y):
+    """
+    test summary requires fitted model
+    """
+    X, y = mcycle_X_y
+    gam = LinearGAM()
+    try:
+        gam.summary()
+    except AttributeError:
+        assert(True)
+
+def test_set_params_with_external_param():
+    """
+    test set_params sets a real parameter
+    """
+    gam = GAM(lam=1)
+    gam.set_params(lam=420)
+    assert(gam.lam == 420)
+
+def test_set_params_with_hidden_param():
+    """
+    test set_params should not set any params that are not exposed to the user
+    """
+    gam = GAM()
+    gam.set_params(_lam=420)
+    assert(gam._lam != 420)
+
+def test_set_params_with_phony_param():
+    """
+    test set_params should not set any phony param
+    """
+    gam = GAM()
+    gam.set_params(cat=420)
+    assert(not hasattr(gam, 'cat'))
+
+def test_set_params_with_hidden_param_deep():
+    """
+    test set_params can set hidden params if we use the deep=True
+    """
+    gam = GAM()
+    assert(gam._lam != 420)
+
+    gam.set_params(_lam=420, deep=True)
+    assert(gam._lam == 420)
+
+def test_set_params_with_phony_param_force():
+    """
+    test set_params can set phony params if we use the force=True
+    """
+    gam = GAM()
+    assert(not hasattr(gam, 'cat'))
+
+    gam.set_params(cat=420, force=True)
+    assert(gam.cat == 420)
+
+def test_get_params():
+    """
+    test gam gets our params
+    """
+    gam = GAM(lam=420)
+    params = gam.get_params()
+    assert(params['lam'] == 420)
+
+def test_get_params_hidden():
+    """
+    test gam gets our params only if we do deep=True
+    """
+    gam = GAM()
+    params = gam.get_params()
+    assert('_lam' not in list(params.keys()))
+
+    params = gam.get_params(deep=True)
+    assert('_lam' in list(params.keys()))
+
+
+class TestSamplingFromPosterior(object):
+
+    def test_drawing_samples_from_unfitted_model(self, mcycle_X_y, mcycle_gam):
+        X, y = mcycle_X_y
+        gam = LinearGAM()
+
+        with pytest.raises(AttributeError):
+            gam.sample(X, y)
+
+        with pytest.raises(AttributeError):
+            gam._sample_coef(X, y)
+
+        with pytest.raises(AttributeError):
+            gam._bootstrap_samples_of_smoothing(X, y)
+
+        assert mcycle_gam._is_fitted
+
+        mcycle_gam.sample(X, y, n_draws=2)
+        mcycle_gam._sample_coef(X, y, n_draws=2)
+        mcycle_gam._bootstrap_samples_of_smoothing(X, y, n_bootstraps=1)
+        assert True
+
+    def test_sample_quantity(self, mcycle_X_y, mcycle_gam):
+        X, y = mcycle_X_y
+        for quantity in ['coefficients', 'response']:
+            with pytest.raises(ValueError):
+                mcycle_gam.sample(X, y, quantity=quantity, n_draws=2)
+        for quantity in ['coef', 'mu', 'y']:
+            mcycle_gam.sample(X, y, quantity=quantity, n_draws=2)
+            assert True
+
+    def test_shape_of_random_samples(self, mcycle_X_y, mcycle_gam):
+        X, y = mcycle_X_y
+        n_samples = len(X)
+        n_draws = 5
+
+        sample_coef = mcycle_gam.sample(X, y, quantity='coef', n_draws=n_draws)
+        sample_mu = mcycle_gam.sample(X, y, quantity='mu', n_draws=n_draws)
+        sample_y = mcycle_gam.sample(X, y, quantity='y', n_draws=n_draws)
+        assert sample_coef.shape == (n_draws, len(mcycle_gam.coef_))
+        assert sample_mu.shape == (n_draws, n_samples)
+        assert sample_y.shape == (n_draws, n_samples)
+
+        XX = generate_X_grid(mcycle_gam)
+        n_samples_in_grid = len(XX)
+        sample_coef = mcycle_gam.sample(X, y, quantity='coef', n_draws=n_draws,
+                                        sample_at_X=XX)
+        sample_mu = mcycle_gam.sample(X, y, quantity='mu', n_draws=n_draws,
+                                        sample_at_X=XX)
+        sample_y = mcycle_gam.sample(X, y, quantity='y', n_draws=n_draws,
+                                        sample_at_X=XX)
+
+        assert sample_coef.shape == (n_draws, len(mcycle_gam.coef_))
+        assert sample_mu.shape == (n_draws, n_samples_in_grid)
+        assert sample_y.shape == (n_draws, n_samples_in_grid)
+
+    def test_shape_bootstrap_samples_of_smoothing(self, mcycle_X_y, mcycle_gam):
+        X, y = mcycle_X_y
+
+        for n_bootstraps in [1, 2]:
+            coef_bootstraps, cov_bootstraps = (
+                mcycle_gam._bootstrap_samples_of_smoothing(
+                    X, y, n_bootstraps=n_bootstraps))
+            assert len(coef_bootstraps) == len(cov_bootstraps) == n_bootstraps
+            for coef, cov in zip(coef_bootstraps, cov_bootstraps):
+                assert coef.shape == mcycle_gam.coef_.shape
+                assert cov.shape == mcycle_gam.statistics_['cov'].shape
+
+            for n_draws in [1, 2]:
+                coef_draws = mcycle_gam._simulate_coef_from_bootstraps(
+                    n_draws, coef_bootstraps, cov_bootstraps)
+                assert coef_draws.shape == (n_draws, len(mcycle_gam.coef_))
+
+    def test_bad_sample_params(self, mcycle_X_y, mcycle_gam):
+        X, y = mcycle_X_y
+        with pytest.raises(ValueError):
+            mcycle_gam.sample(X, y, n_draws=0)
+        with pytest.raises(ValueError):
+            mcycle_gam.sample(X, y, n_bootstraps=0)
+
+
+def test_prediction_interval_unknown_scale():
+    """
+    the prediction intervals should be correct to a few decimal places
+    we test at a large sample limit, where the t distribution becomes normal
+    """
+    n = 1000000
+    X = np.linspace(0,1,n)
+    y = np.random.randn(n)
+
+    gam_a = LinearGAM(fit_linear=True, fit_splines=False).fit(X, y)
+    gam_b = LinearGAM(n_splines=4).fit(X, y)
+
+    XX = generate_X_grid(gam_a)
+    intervals_a = gam_a.prediction_intervals(XX, quantiles=[0.1, .9]).mean(axis=0)
+    intervals_b = gam_b.prediction_intervals(XX, quantiles=[0.1, .9]).mean(axis=0)
+
+    assert np.allclose(intervals_a[0], sp.stats.norm.ppf(0.1), atol=0.01)
+    assert np.allclose(intervals_a[1], sp.stats.norm.ppf(0.9), atol=0.01)
+
+    assert np.allclose(intervals_b[0], sp.stats.norm.ppf(0.1), atol=0.01)
+    assert np.allclose(intervals_b[1], sp.stats.norm.ppf(0.9), atol=0.01)
+
+def test_prediction_interval_known_scale():
+    """
+    the prediction intervals should be correct to a few decimal places
+    we test at a large sample limit.
+    """
+    n = 1000000
+    X = np.linspace(0,1,n)
+    y = np.random.randn(n)
+
+    gam_a = LinearGAM(fit_linear=True, fit_splines=False, scale=1.).fit(X, y)
+    gam_b = LinearGAM(n_splines=4, scale=1.).fit(X, y)
+
+    XX = generate_X_grid(gam_a)
+    intervals_a = gam_a.prediction_intervals(XX, quantiles=[0.1, .9]).mean(axis=0)
+    intervals_b = gam_b.prediction_intervals(XX, quantiles=[0.1, .9]).mean(axis=0)
+
+    assert np.allclose(intervals_a[0], sp.stats.norm.ppf(0.1), atol=0.01)
+    assert np.allclose(intervals_a[1], sp.stats.norm.ppf(0.9), atol=0.01)
+
+    assert np.allclose(intervals_b[0], sp.stats.norm.ppf(0.1), atol=0.01)
+    assert np.allclose(intervals_b[1], sp.stats.norm.ppf(0.9), atol=0.01)
+
+def test_pvalue_rejects_useless_feature(wage_X_y):
+    """
+    check that a p-value can reject a useless feature
+    """
+    X, y = wage_X_y
+
+    # add empty feature
+    X = np.c_[X, np.zeros(X.shape[0])]
+    gam = LinearGAM().fit(X, y)
+
+    # now do the test, with some safety
+    p_values = gam._estimate_p_values()
+    assert(p_values[-1] > .9)
+
+def test_pvalue_invariant_to_scale(wage_X_y):
+    """
+    regression test.
+
+    a bug made the F-statistic sensitive to scale changes, when it should be invariant.
+
+    check that a p-value should not change when we change the scale of the response
+    """
+    X, y = wage_X_y
+
+    gamA = LinearGAM(n_splines=10).fit(X, y * 1000000)
+    gamB = LinearGAM(n_splines=10).fit(X, y)
+
+    assert np.allclose(gamA.statistics_['p_values'], gamB.statistics_['p_values'])
+
 
 def test_2d_y_still_allow_fitting_in_PoissonGAM(coal_X_y):
     """

--- a/pygam/tests/test_GAM_methods.py
+++ b/pygam/tests/test_GAM_methods.py
@@ -513,3 +513,20 @@ def test_2d_y_still_allow_fitting_in_PoissonGAM(coal_X_y):
     # 2d exposure should cause no problems now
     gam = PoissonGAM().fit(X, y, exposure=two_d_data)
     assert gam._is_fitted
+
+def test_non_int_exposure_produced_no_inf_in_PoissonGAM_ll(coal_X_y):
+    """
+    regression test.
+
+    there was a bug where we forgot to round the rescaled counts before
+    computing the loglikelihood. since Poisson requires integer observations,
+    small numerical errors caused the pmf to return -inf, which shows up
+    in the loglikelihood computations, AIC, AICc..
+    """
+    X, y = coal_X_y
+
+    rate = 1.2 + np.cos(np.linspace(0, 2. * np.pi, len(y)))
+
+    gam = PoissonGAM().fit(X, y, exposure=rate)
+
+    assert np.isfinite(gam.statistics_['loglikelihood'])

--- a/pygam/utils.py
+++ b/pygam/utils.py
@@ -179,14 +179,14 @@ def make_2d(array, verbose=True):
     return array
 
 
-def check_array(array, force_2d=False, n_feats=None, n_dims=None,
+def check_array(array, force_2d=False, n_feats=None, ndim=None,
                 min_samples=1, name='Input data', verbose=True):
     """
     tool to perform basic data validation.
     called by check_X and check_y.
 
     ensures that data:
-    - is n_dims dimensional
+    - is ndim dimensional
     - contains float-compatible data-types
     - has at least min_samples
     - has n_feats
@@ -196,11 +196,11 @@ def check_array(array, force_2d=False, n_feats=None, n_dims=None,
     ----------
     array : array-like
     force_2d : boolean, default: False
-        whether to force a 2d array. Setting to True forces n_dims = 2
+        whether to force a 2d array. Setting to True forces ndim = 2
     n_feats : int, default: None
               represents number of features that the array should have.
               not enforced if n_feats is None.
-    n_dims : int default: None
+    ndim : int default: None
         number of dimensions expected in the array
     min_samples : int, default: 1
     name : str, default: 'Input data'
@@ -215,7 +215,7 @@ def check_array(array, force_2d=False, n_feats=None, n_dims=None,
     # make array
     if force_2d:
         array = make_2d(array, verbose=verbose)
-        n_dims = 2
+        ndim = 2
     else:
         array = np.array(array)
 
@@ -234,11 +234,11 @@ def check_array(array, force_2d=False, n_feats=None, n_dims=None,
     if not(np.isfinite(array).all()):
         raise ValueError('{} must not contain Inf nor NaN'.format(name))
 
-    # check n_dims
-    if n_dims is not None:
-        if array.ndim != n_dims:
+    # check ndim
+    if ndim is not None:
+        if array.ndim != ndim:
             raise ValueError('{} must have {} dimensions. '\
-                             'found shape {}'.format(name, n_dims, array.shape))
+                             'found shape {}'.format(name, ndim, array.shape))
 
     # check n_feats
     if n_feats is not None:
@@ -279,7 +279,7 @@ def check_y(y, link, dist, min_samples=1, verbose=True):
     """
     y = np.ravel(y)
 
-    y = check_array(y, force_2d=False, min_samples=min_samples, n_dims=1,
+    y = check_array(y, force_2d=False, min_samples=min_samples, ndim=1,
                     name='y data', verbose=verbose)
 
     warnings.filterwarnings('ignore', 'divide by zero encountered in log')


### PR DESCRIPTION
- [x] PoissonGAM checks shape of exposure, weight and observation arrays before fitting
- [x] rounding and casting observations to `int` before computing Poisson pmf fixes `-inf ` in model summary (https://github.com/dswah/pyGAM/issues/173)