### PR TITLE
[WIP] improve Gridsearch

### DIFF
--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -2104,6 +2104,10 @@ class GAM(Core):
 
             # prepare grid
             if any(isiterable(g) for g in grid):
+                # then we know that the param grid must be the length of n_features
+                if len(grid) != X.shape[1]:
+                    raise ValueError('The dimension of the search grid must equal n-features '\
+                                     'n-feature = {}, grid-dimension = {}'.format(X.shape[1], len(grid)))
                 # cast to np.array
                 grid = [np.atleast_1d(g) for g in grid]
 

--- a/pygam/tests/test_gridsearch.py
+++ b/pygam/tests/test_gridsearch.py
@@ -165,3 +165,29 @@ def test_no_models_fitted(mcycle_X_y):
     assert(not isinstance(scores, dict))
     assert(isinstance(scores, LinearGAM))
     assert(not scores._is_fitted)
+
+def test_grid_dimension_not_equal_feature_dimension(wage_X_y):
+    """
+    regression test
+
+    in gridsearch we need the dimensionality of the search space to equal
+    the number of features.
+
+    otherwise we need to raise a ValueError so as not to fail silently
+    """
+    X, y = wage_X_y
+
+    m = X.shape[1]
+    base_grid = [[1, 10]]
+
+    # grid dimension too small
+    with pytest.raises(ValueError):
+        LinearGAM().gridsearch(X, y, lam=base_grid * (m-1))
+
+    # grid dimension too large
+    with pytest.raises(ValueError):
+        LinearGAM().gridsearch(X, y, lam=base_grid * (m+1))
+
+    # grid dimension correct
+    # grid dimension too small
+    LinearGAM().gridsearch(X, y, lam=base_grid * m)


### PR DESCRIPTION
- [ ] gridsearch should allow randomsearch-like behavior: ie pre-specify a grid for all lams, without relying on `combine()` do find the cartesian product 
- [ ] gridsearch should raise ValueError if grid dimensions cannot be inferred correctly
- [ ] gridsearch allows parallelism
- [ ] `n_jobs` is argument
- [ ] `gam.sample()` uses multiple bootstraps with random-search 
- [ ] tests