### PR TITLE
Easy plural

### DIFF
--- a/pygam/__init__.py
+++ b/pygam/__init__.py
@@ -21,4 +21,4 @@ from pygam.terms import intercept
 __all__ = ['GAM', 'LinearGAM', 'LogisticGAM', 'GammaGAM', 'PoissonGAM',
            'InvGaussGAM', 'ExpectileGAM', 'l', 's', 'f', 'te', 'intercept']
 
-__version__ = '0.6.0'
+__version__ = '0.6.1'

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -308,8 +308,6 @@ class GAM(Core, MetaTermMixin):
                 setattr(self.terms, k, v)
                 remove.append(k)
         for k in remove:
-            # if k == 'lam':
-            #     continue
             delattr(self, k)
 
         self.terms.compile(X)

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -104,14 +104,6 @@ class GAM(Core, MetaTermMixin):
     link : str or Link object, default: 'identity'
         Link function to use in the model.
 
-    lam : float or iterable of floats > 0, default: 0.6
-        Smoothing strength; must be a positive float, or one positive float
-        per feature.
-
-        Larger values enforce stronger smoothing.
-
-        If only one float is specified, then it is copied for all features.
-
     fit_intercept : bool, default: True
         Specifies if a constant (a.k.a. bias or intercept) should be
         added to the decision function.
@@ -2136,14 +2128,6 @@ class LinearGAM(GAM):
                 default: ['deviance', 'diffs']
         Names of callback objects to call during the optimization loop.
 
-    lam : float or iterable of floats > 0, default: 0.6
-        Smoothing strength; must be a positive float, or one positive float
-        per feature.
-
-        Larger values enforce stronger smoothing.
-
-        If only one float is specified, then it is copied for all features.
-
     fit_intercept : bool, default: True
         Specifies if a constant (a.k.a. bias or intercept) should be
         added to the decision function.
@@ -2268,14 +2252,6 @@ class LogisticGAM(GAM):
     callbacks : list of strings or list of CallBack objects,
                 default: ['deviance', 'diffs']
         Names of callback objects to call during the optimization loop.
-
-    lam : float or iterable of floats > 0, default: 0.6
-        Smoothing strength; must be a positive float, or one positive float
-        per feature.
-
-        Larger values enforce stronger smoothing.
-
-        If only one float is specified, then it is copied for all features.
 
     fit_intercept : bool, default: True
         Specifies if a constant (a.k.a. bias or intercept) should be
@@ -2424,14 +2400,6 @@ class PoissonGAM(GAM):
     callbacks : list of strings or list of CallBack objects,
                 default: ['deviance', 'diffs']
         Names of callback objects to call during the optimization loop.
-
-    lam : float or iterable of floats > 0, default: 0.6
-        Smoothing strength; must be a positive float, or one positive float
-        per feature.
-
-        Larger values enforce stronger smoothing.
-
-        If only one float is specified, then it is copied for all features.
 
     fit_intercept : bool, default: True
         Specifies if a constant (a.k.a. bias or intercept) should be
@@ -2780,14 +2748,6 @@ class GammaGAM(GAM):
                 default: ['deviance', 'diffs']
         Names of callback objects to call during the optimization loop.
 
-    lam : float or iterable of floats > 0, default: 0.6
-        Smoothing strength; must be a positive float, or one positive float
-        per feature.
-
-        Larger values enforce stronger smoothing.
-
-        If only one float is specified, then it is copied for all features.
-
     fit_intercept : bool, default: True
         Specifies if a constant (a.k.a. bias or intercept) should be
         added to the decision function.
@@ -2901,14 +2861,6 @@ class InvGaussGAM(GAM):
                 default: ['deviance', 'diffs']
         Names of callback objects to call during the optimization loop.
 
-    lam : float or iterable of floats > 0, default: 0.6
-        Smoothing strength; must be a positive float, or one positive float
-        per feature.
-
-        Larger values enforce stronger smoothing.
-
-        If only one float is specified, then it is copied for all features.
-
     fit_intercept : bool, default: True
         Specifies if a constant (a.k.a. bias or intercept) should be
         added to the decision function.
@@ -3014,14 +2966,6 @@ class ExpectileGAM(GAM):
     callbacks : list of strings or list of CallBack objects,
                 default: ['deviance', 'diffs']
         Names of callback objects to call during the optimization loop.
-
-    lam : float or iterable of floats > 0, default: 0.6
-        Smoothing strength; must be a positive float, or one positive float
-        per feature.
-
-        Larger values enforce stronger smoothing.
-
-        If only one float is specified, then it is copied for all features.
 
     fit_intercept : bool, default: True
         Specifies if a constant (a.k.a. bias or intercept) should be

--- a/pygam/tests/test_GAM_methods.py
+++ b/pygam/tests/test_GAM_methods.py
@@ -224,14 +224,6 @@ def test_set_params_with_external_param():
     gam.set_params(lam=420)
     assert(gam.lam == 420)
 
-def test_set_params_with_hidden_param():
-    """
-    test set_params should not set any params that are not exposed to the user
-    """
-    gam = GAM()
-    gam.set_params(_lam=420)
-    assert(gam._lam != 420)
-
 def test_set_params_with_phony_param():
     """
     test set_params should not set any phony param
@@ -239,16 +231,6 @@ def test_set_params_with_phony_param():
     gam = GAM()
     gam.set_params(cat=420)
     assert(not hasattr(gam, 'cat'))
-
-def test_set_params_with_hidden_param_deep():
-    """
-    test set_params can set hidden params if we use the deep=True
-    """
-    gam = GAM()
-    assert(gam._lam != 420)
-
-    gam.set_params(_lam=420, deep=True)
-    assert(gam._lam == 420)
 
 def test_set_params_with_phony_param_force():
     """
@@ -267,17 +249,6 @@ def test_get_params():
     gam = GAM(lam=420)
     params = gam.get_params()
     assert(params['lam'] == 420)
-
-def test_get_params_hidden():
-    """
-    test gam gets our params only if we do deep=True
-    """
-    gam = GAM()
-    params = gam.get_params()
-    assert('_lam' not in list(params.keys()))
-
-    params = gam.get_params(deep=True)
-    assert('_lam' in list(params.keys()))
 
 
 class TestSamplingFromPosterior(object):

--- a/pygam/tests/test_GAM_params.py
+++ b/pygam/tests/test_GAM_params.py
@@ -62,11 +62,35 @@ def test_linear_regression(mcycle_X_y):
 
 def test_compute_stats_even_if_not_enough_iters(default_X_y):
     """
-    should be able to do linear regression
+    GAM should collect model statistics after optimization ends even if it didnt converge
     """
     X, y = default_X_y
     gam = LogisticGAM(max_iter=1).fit(X, y)
     assert(hasattr(gam, 'statistics_'))
+
+def test_easy_plural_arguments(wage_X_y):
+    """
+    it should easy to set global term arguments
+    """
+    X, y = wage_X_y
+
+    gam = LinearGAM(n_splines=10).fit(X, y)
+    assert gam._is_fitted
+    assert gam.n_splines == [10] * X.shape[1]
+
+class TestRegressions(object):
+    def test_no_explicit_terms_custom_lambda(self, wage_X_y):
+        X, y = wage_X_y
+
+        # before easy-pluralization, this command would fail
+        gam = LinearGAM(lam=0.6).gridsearch(X, y)
+        assert gam._is_fitted
+
+        # same with
+        gam = LinearGAM()
+        gam.n_splines = 10
+        gam.gridsearch(X, y)
+        assert gam._is_fitted
 
 # TODO categorical dtypes get no fit linear even if fit linear TRUE
 # TODO categorical dtypes get their own number of splines


### PR DESCRIPTION
- makes setting term attributes more consistent so:
```python
gam = GAM(terms='auto')
gam.n_splines = 5
```
**doesnt fail** and is equivalent to 

```python
gam = GAM(s(0, n_splines=5))
```

- term parameters should be easier to broadcast:
```python
GAM(terms=s(0) + s(1), n_splines=10)
```
is equivalent to
```python
GAM(terms=s(0, n_splines=10) + s(1, n_splines=10))
```
