### PR TITLE
No auto

### DIFF
--- a/pygam/__init__.py
+++ b/pygam/__init__.py
@@ -21,4 +21,4 @@ from pygam.terms import intercept
 __all__ = ['GAM', 'LinearGAM', 'LogisticGAM', 'GammaGAM', 'PoissonGAM',
            'InvGaussGAM', 'ExpectileGAM', 'l', 's', 'f', 'te', 'intercept']
 
-__version__ = '0.6.1'
+__version__ = '0.6.2'

--- a/pygam/__init__.py
+++ b/pygam/__init__.py
@@ -21,4 +21,4 @@ from pygam.terms import intercept
 __all__ = ['GAM', 'LinearGAM', 'LogisticGAM', 'GammaGAM', 'PoissonGAM',
            'InvGaussGAM', 'ExpectileGAM', 'l', 's', 'f', 'te', 'intercept']
 
-__version__ = '0.6.2'
+__version__ = '0.6.3'

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -1089,7 +1089,7 @@ class GAM(Core, MetaTermMixin):
         None
         """
         if mu is None:
-            mu = self.predict_mu_(X=X)
+            mu = self.predict_mu(X=X)
 
         if weights is None:
             weights = np.ones_like(y).astype('float64')

--- a/pygam/terms.py
+++ b/pygam/terms.py
@@ -15,17 +15,6 @@ from pygam.core import Core, nice_repr
 from pygam.utils import isiterable, check_param, flatten, gen_edge_knots, b_spline_basis, tensor_product
 from pygam.penalties import PENALTIES, CONSTRAINTS
 
-DEFAULTS = {'lam': 0.6,
-            'dtype': 'numerical',
-            'fit_linear': False,
-            'fit_splines': True,
-            'penalties': 'auto',
-            'constraints': None,
-            'basis': 'ps',
-            'by': None,
-            'spline_order': 3,
-            'n_splines': 20
-            }
 
 class Term(Core):
     __metaclass__ = ABCMeta
@@ -151,9 +140,8 @@ class Term(Core):
         None
         """
         # dtype
-        if self.dtype not in ['auto', 'numerical', 'categorical']:
-            raise ValueError("dtype must be in ['auto', 'numerical', "\
-                             "'categorical'], "\
+        if self.dtype not in ['numerical', 'categorical']:
+            raise ValueError("dtype must be in ['numerical','categorical'], "\
                              "but found dtype = {}".format(self.dtype))
 
         # fit_linear XOR fit_splines

--- a/pygam/tests/test_terms.py
+++ b/pygam/tests/test_terms.py
@@ -194,4 +194,4 @@ def test_correct_smoothing_in_tensors(toy_interaction_X_y):
 class TestRegressions(object):
     def test_no_auto_dtype(self):
         with pytest.raises(ValueError):
-            Term(feature=0, dtype='auto')
+            SplineTerm(feature=0, dtype='auto')

--- a/pygam/tests/test_terms.py
+++ b/pygam/tests/test_terms.py
@@ -190,3 +190,8 @@ def test_correct_smoothing_in_tensors(toy_interaction_X_y):
     #  smoothing the sinusoid function heavily reduces fit quality
     gam = LinearGAM(te(0, 1, lam=[10000, 0.6])).fit(X, y)
     assert gam.statistics_['pseudo_r2']['explained_deviance'] < 0.1
+
+class TestRegressions(object):
+    def test_no_auto_dtype(self):
+        with pytest.raises(ValueError):
+            Term(feature=0, dtype='auto')


### PR DESCRIPTION
- [x] get rid of spurious references to auto dtype
- [x] estimate r-squared no longer references nonexistent method when argument `mu=None`  