### PR TITLE
Fix not-None element existance judgement bug

### DIFF
--- a/pygam/terms.py
+++ b/pygam/terms.py
@@ -241,7 +241,7 @@ class Term(Core):
     def hasconstraint(self):
         """bool, whether the term has any constraints
         """
-        return (np.atleast_1d(self.constraints) != None).any()
+        return np.not_equal(np.atleast_1d(self.constraints), None).any()
 
     @property
     @abstractproperty


### PR DESCRIPTION
Fixed a bug that the function want to judge whether element == None for each element in the ndarray but actually judge whether None == array itself.