### PR TITLE
Score method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ Thumbs.db
 #############
 dist
 .cache
+.pytest_cache
 
 # Documentation
 ###############

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 # pyGAM
 Generalized Additive Models in Python.
+Jonah test
 
 <img src=imgs/pygam_tensor.png>
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 
 # pyGAM
 Generalized Additive Models in Python.
-Jonah test
 
 <img src=imgs/pygam_tensor.png>
 

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -924,6 +924,34 @@ class GAM(Core, MetaTermMixin):
         #     self._pirls_naive(X, y)
         return self
 
+    def score(self, X, y, weights=None):
+
+        if not self._is_fitted:
+            raise AttributeError('GAM has not been fitted. Call fit first.')
+
+        y = check_y(y, self.link, self.distribution, verbose=self.verbose)
+        X = check_X(X, n_feats=self.statistics_['m_features'],
+                    edge_knots=self.edge_knots_, dtypes=self.dtype,
+                    features=self.feature, verbose=self.verbose)
+        check_X_y(X, y)
+
+        if weights is not None:
+            weights = np.array(weights).astype('f').ravel()
+            weights = check_array(weights, name='sample weights',
+                                  ndim=1, verbose=self.verbose)
+            check_lengths(y, weights)
+        else:
+            weights = np.ones_like(y).astype('float64')
+
+        y_pred = self.predict(X)
+
+        # R^2 calculations
+        numerator = (weights * (y - y_pred) ** 2).sum()
+        denominator = (weights * (y - np.average(y, weights=weights)) ** 2).sum()
+
+        return 1 - numerator/denominator
+
+
     def deviance_residuals(self, X, y, weights=None, scaled=False):
         """
         method to compute the deviance residuals of the model

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -925,7 +925,24 @@ class GAM(Core, MetaTermMixin):
         return self
 
     def score(self, X, y, weights=None):
+        """
+        method to compte R^2 for a trained model for a given X data and y labels
 
+        Parameters
+        ----------
+        X : array-like
+            Input data array of shape (n_samples, m_features)
+        y : array-like
+            Output data vector of shape (n_samples,)
+        weights : array-like shape (n_samples,) or None, optional
+            Sample weights.
+            if None, defaults to array of ones
+
+        Returns
+        -------
+        R^2 score: np.array() (n_samples,)
+
+        """
         if not self._is_fitted:
             raise AttributeError('GAM has not been fitted. Call fit first.')
 
@@ -961,7 +978,7 @@ class GAM(Core, MetaTermMixin):
         Parameters
         ----------
         X : array-like
-            Input data array of shape (n_saples, m_features)
+            Input data array of shape (n_samples, m_features)
         y : array-like
             Output data vector of shape (n_samples,)
         weights : array-like shape (n_samples,) or None, optional

--- a/pygam/tests/test_GAM_methods.py
+++ b/pygam/tests/test_GAM_methods.py
@@ -532,3 +532,13 @@ class TestRegressions(object):
         """
         X, y = mcycle_X_y
         mcycle_gam._estimate_r2(X, y)
+
+    def test_score_method(self, mcycle_gam, mcycle_X_y):
+        """
+        regression test
+
+        score returns calculated r^2 for X data using trained gam
+
+        """
+        X, y = mcycle_X_y
+        assert mcycle_gam.score(X, y) < 1

--- a/pygam/tests/test_GAM_methods.py
+++ b/pygam/tests/test_GAM_methods.py
@@ -541,4 +541,4 @@ class TestRegressions(object):
 
         """
         X, y = mcycle_X_y
-        assert mcycle_gam.score(X, y) < 1
+        assert mcycle_gam.score(X, y) <= 1


### PR DESCRIPTION
Hi @dswah, I have added a GAM.score method to the base GAM class following from issue #102.
I have also added a simple test for the score method to quickly check that it the score method without crashing and checks that the score which is R^2 is <=1.

Currently it only calculates the R^2 which is the default score in scikit-learn for regression models. I can also add the accuracy score specifically to the LogisticGam class. 

I am quite new to github and this whole open source concept, so I would appreciate any feedback!
Let me know if the code makes sense or if I am completely off.
Thanks!