### PR TITLE
Typo fix (uppercase "Poisson" instead of "poission")

### DIFF
--- a/doc/source/notebooks/tour_of_pygam.ipynb
+++ b/doc/source/notebooks/tour_of_pygam.ipynb
@@ -148,7 +148,7 @@
     "\n",
     "- `LinearGAM` identity link and normal distribution\n",
     "- `LogisticGAM` logit link and binomial distribution\n",
-    "- `PoissonGAM` log link and poission distribution\n",
+    "- `PoissonGAM` log link and Poisson distribution\n",
     "- `GammaGAM` log link and gamma distribution\n",
     "- `InvGauss` log link and inv_gauss distribution\n",
     "\n",


### PR DESCRIPTION
Very minor change in the doc