### PR TITLE
pygam/{core,pygam}: fix literal identity check

### DIFF
--- a/pygam/core.py
+++ b/pygam/core.py
@@ -54,7 +54,7 @@ def nice_repr(name, param_kvs, line_width=30, line_offset=5, decimals=3, args=No
 
         # flatten sub-term properties, but not `terms`
         k, v = param_kvs.pop()
-        if flatten_attrs and k is not 'terms':
+        if flatten_attrs and k != 'terms':
             v = flatten(v)
 
         # round the floats first

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -222,7 +222,7 @@ class GAM(Core, MetaTermMixin):
                              .format(self.fit_intercept.__class__))
 
         # terms
-        if (self.terms is not 'auto') and not (isinstance(self.terms, (TermList, Term, type(None)))):
+        if (self.terms != 'auto') and not (isinstance(self.terms, (TermList, Term, type(None)))):
             raise ValueError('terms must be a TermList, but found '\
                              'terms = {}'.format(self.terms))
 
@@ -273,7 +273,7 @@ class GAM(Core, MetaTermMixin):
         n_samples, m_features = X.shape
 
         # terms
-        if self.terms is 'auto':
+        if self.terms == 'auto':
             # one numerical spline per feature
             self.terms = TermList(*[SplineTerm(feat, verbose=self.verbose) for feat in range(m_features)])
 


### PR DESCRIPTION
This commit changes the checks against literal values from identity to
equality, as recommended in Python 3.8.

Fixes: https://github.com/dswah/pyGAM/issues/260

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>