### PR TITLE
Added "terms" and "response" type

### DIFF
--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -431,10 +431,12 @@ class GAM(Core, MetaTermMixin):
         y : np.array of shape (n_samples,)
             containing predicted values under the model
         
-        type_ : response or terms, optional
+        type_ : str in {'response','terms'}
                 response to provide prediction values.
                 terms to provide the terms values in linear portion.
         """
+        if type_ not in ['response','terms']:
+            raise ValueError('type_ not equal to response or terms.')
         if type_ == 'terms':
             term_values = [self._linear_predictor(X,term = term) for term in self.terms]
             return term_values

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -416,7 +416,7 @@ class GAM(Core, MetaTermMixin):
         lp = self._linear_predictor(X)
         return self.link.mu(lp, self.distribution)
 
-    def predict(self, X):
+    def predict(self, X, type_ = "response"):
         """
         preduct expected value of target given model and input X
         often this is done via expected value of GAM given input X
@@ -430,7 +430,14 @@ class GAM(Core, MetaTermMixin):
         -------
         y : np.array of shape (n_samples,)
             containing predicted values under the model
+        
+        type_ : response or terms, optional
+                response to provide prediction values.
+                terms to provide the terms values in linear portion.
         """
+        if type_ == 'terms':
+            term_values = [self._linear_predictor(X,term = term) for term in self.terms]
+            return term_values
         return self.predict_mu(X)
 
     def _modelmat(self, X, term=-1):


### PR DESCRIPTION
Added "terms" and "response" type in predict method of the GAM class in similarity with mgcv package in r. The default type_ parameter is "response" which provides the prediction value. When type_ parameter is set to "terms", term wise contribution in the linear part of the prediction for each feature is provided. 