### PR TITLE
Updated documentation reference code on tuning a linearGAM model

### DIFF
--- a/doc/source/notebooks/quick_start.ipynb
+++ b/doc/source/notebooks/quick_start.ipynb
@@ -291,8 +291,8 @@
    "outputs": [],
    "source": [
     "lams = np.random.rand(100, 3) # random points on [0, 1], with shape (100, 3)\n",
-    "lams = lams * 8 - 3 # shift values to -3, 3\n",
-    "lams = np.exp(lams) # transforms values to 1e-3, 1e3"
+    "lams = lams * 6 - 3 # shift values to -3, 3\n",
+    "lams = 10 ** lams # transforms values to 1e-3, 1e3"
    ]
   },
   {


### PR DESCRIPTION
Updated documentation reference code on tuning a linearGAM model to be accurate compared to what the comments describe.

In the original reference code the numerical outputs at each step did not match the expected results based on the comments:
`lams = np.random.rand(100, 3) # random points on [0, 1], with shape (100, 3)`
`lams = lams * 8 - 3 # shift values to -3, 3`
`lams = np.exp(lams) # transforms values to 1e-3, 1e3`

The second step `lams = lams * 8 - 3 # shift values to -3, 3` results in shifting the random values from -3,5 rather than -3,3.

The third step `lams = np.exp(lams) # transforms values to 1e-3, 1e3` is computing e^lams when is seems like it is supposed to be computing 10^lams.

After running the original reference code, the min and max values are the resulting matrix are 0.04992659817158999 and 148.3540116029961 respectively.

The reference code in the quick_start.ipynb notebook was modified to:
`lams = np.random.rand(100, 3) # random points on [0, 1], with shape (100, 3)`
`lams = lams * 6 - 3 # shift values to -3, 3`
`lams = 10 ** lams # transforms values to 1e-3, 1e3`

Which results in more correct minimum and maximum values in the range of [1e-3, 1e3].