### PR TITLE
Update the stringdoc of FactorTerm in terms.py

### DIFF
--- a/pygam/terms.py
+++ b/pygam/terms.py
@@ -825,9 +825,8 @@ class FactorTerm(SplineTerm):
 
             Custom penalties can be passed as a callable.
 
-        coding : {'one-hot'} type of contrast encoding to use.
-            currently, only 'one-hot' encoding has been developed.
-            this means that we fit one coefficient per category.
+        coding : {'one-hot', 'dummy'} type of contrast encoding to use.
+            'one-hot' keeps all columns while 'dummy' drops the first column.
 
         Attributes
         ----------


### PR DESCRIPTION
The stringdoc for FactorTerm specifies that only 'one-hot' coding has been implemented but dummy has been implemented as well.