### PR TITLE
Fix error with data ownership in cholesky

### DIFF
--- a/pygam/utils.py
+++ b/pygam/utils.py
@@ -56,6 +56,8 @@ def cholesky(A, sparse=True, verbose=True):
             # permutation matrix P
             P = sp.sparse.lil_matrix(A.shape)
             p = F.P()
+            # require OWNDATA = True
+            p = np.require(p, requirements='O')
             P[np.arange(len(p)), p] = 1
 
             # permute


### PR DESCRIPTION
Require that the fill-reducing permutation P of Cholesky factorizer owns its data before use. Fixes #271

This sets the `OWNDATA` flag of its data to `True` - in traceback it can be seen that `col` (line 102 of `scipy/sparse/_index.py`), which is derived from `p`, has this flag set to false. This creates a copy of the data if necessary (which apparently it wasn't in previous versions?)

Someone should give this patch a shot on their machine as well.