### PR TITLE
empty sparse matrices dont need np.zeros

### DIFF
--- a/pygam/penalties.py
+++ b/pygam/penalties.py
@@ -257,7 +257,7 @@ def none(n, coef):
     -------
     penalty matrix : sparse csc matrix of shape (n,n)
     """
-    return sp.sparse.csc_matrix(np.zeros((n, n)))
+    return sp.sparse.csc_matrix((n, n))
 
 def wrap_penalty(p, fit_linear, linear_penalty=0.):
     """

--- a/pygam/terms.py
+++ b/pygam/terms.py
@@ -625,7 +625,7 @@ class SplineTerm(Term):
             Type of basis function to use in the term.
 
             'ps' : p-spline basis
-            
+
             'cp' : cyclic p-spline basis, useful for building periodic functions.
                    by default, the maximum and minimum of the feature values
                    are used to determine the function's period.
@@ -1315,7 +1315,7 @@ class TensorTerm(SplineTerm, MetaTermMixin):
         -------
         P : sparse CSC matrix containing the model penalties in quadratic form
         """
-        P = sp.sparse.csc_matrix(np.zeros((self.n_coefs, self.n_coefs)))
+        P = sp.sparse.csc_matrix((self.n_coefs, self.n_coefs))
         for i in range(len(self._terms)):
             P += self._build_marginal_penalties(i)
 
@@ -1361,7 +1361,7 @@ class TensorTerm(SplineTerm, MetaTermMixin):
         -------
         C : sparse CSC matrix containing the model constraints in quadratic form
         """
-        C = sp.sparse.csc_matrix(np.zeros((self.n_coefs, self.n_coefs)))
+        C = sp.sparse.csc_matrix((self.n_coefs, self.n_coefs))
         for i in range(len(self._terms)):
             C += self._build_marginal_constraints(i, coef, constraint_lam, constraint_l2)
 
@@ -1397,7 +1397,7 @@ class TensorTerm(SplineTerm, MetaTermMixin):
         C : sparse CSC matrix containing the model constraints in quadratic form
         """
 
-        composite_C = np.zeros((len(coef), len(coef)))
+        composite_C = sp.sparse.csc_matrix((len(coef), len(coef)))
 
         for slice_ in self._iterate_marginal_coef_slices(i):
             # get the slice of coefficient vector


### PR DESCRIPTION
we dont need to us `np.zeros(...)` to initialize an empty sparse matrix (since this would also defeat the purpose)