### PR TITLE
Pass callbacks argument to LinearGAM super init - fixes #291

### DIFF
--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -2285,6 +2285,7 @@ class LinearGAM(GAM):
         super(LinearGAM, self).__init__(terms=terms,
                                         distribution=NormalDist(scale=self.scale),
                                         link='identity',
+                                        callbacks=callbacks,
                                         max_iter=max_iter,
                                         tol=tol,
                                         fit_intercept=fit_intercept,


### PR DESCRIPTION
`callbacks` argument to be passed to `LinearGAM`'s `super().__init__()` call.

This basically addresses issue #291 regarding cloning LinearGAM estimator with sklearn functions, like `cross_validate`.