### PR TITLE
Fixed the docstring of GAM classes

### DIFF
--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -122,7 +122,7 @@ class GAM(Core, MetaTermMixin):
     ----------
     coef_ : array, shape (n_classes, m_features)
         Coefficient of the features in the decision function.
-        If fit_intercept is True, then self.coef_[0] will contain the bias.
+        If fit_intercept is True, then self.coef_[-1] will contain the bias.
 
     statistics_ : dict
         Dictionary containing model statistics like GCV/UBRE scores, AIC/c,
@@ -2253,7 +2253,7 @@ class LinearGAM(GAM):
     ----------
     coef_ : array, shape (n_classes, m_features)
         Coefficient of the features in the decision function.
-        If fit_intercept is True, then self.coef_[0] will contain the bias.
+        If fit_intercept is True, then self.coef_[-1] will contain the bias.
 
     statistics_ : dict
         Dictionary containing model statistics like GCV/UBRE scores, AIC/c,
@@ -2373,7 +2373,7 @@ class LogisticGAM(GAM):
     ----------
     coef_ : array, shape (n_classes, m_features)
         Coefficient of the features in the decision function.
-        If fit_intercept is True, then self.coef_[0] will contain the bias.
+        If fit_intercept is True, then self.coef_[-1] will contain the bias.
 
     statistics_ : dict
         Dictionary containing model statistics like GCV/UBRE scores, AIC/c,
@@ -2539,7 +2539,7 @@ class PoissonGAM(GAM):
     ----------
     coef_ : array, shape (n_classes, m_features)
         Coefficient of the features in the decision function.
-        If fit_intercept is True, then self.coef_[0] will contain the bias.
+        If fit_intercept is True, then self.coef_[-1] will contain the bias.
 
     statistics_ : dict
         Dictionary containing model statistics like GCV/UBRE scores, AIC/c,
@@ -2887,7 +2887,7 @@ class GammaGAM(GAM):
     ----------
     coef_ : array, shape (n_classes, m_features)
         Coefficient of the features in the decision function.
-        If fit_intercept is True, then self.coef_[0] will contain the bias.
+        If fit_intercept is True, then self.coef_[-1] will contain the bias.
 
     statistics_ : dict
         Dictionary containing model statistics like GCV/UBRE scores, AIC/c,
@@ -2995,7 +2995,7 @@ class InvGaussGAM(GAM):
     ----------
     coef_ : array, shape (n_classes, m_features)
         Coefficient of the features in the decision function.
-        If fit_intercept is True, then self.coef_[0] will contain the bias.
+        If fit_intercept is True, then self.coef_[-1] will contain the bias.
 
     statistics_ : dict
         Dictionary containing model statistics like GCV/UBRE scores, AIC/c,
@@ -3093,7 +3093,7 @@ class ExpectileGAM(GAM):
     ----------
     coef_ : array, shape (n_classes, m_features)
         Coefficient of the features in the decision function.
-        If fit_intercept is True, then self.coef_[0] will contain the bias.
+        If fit_intercept is True, then self.coef_[-1] will contain the bias.
 
     statistics_ : dict
         Dictionary containing model statistics like GCV/UBRE scores, AIC/c,


### PR DESCRIPTION
According to [this code](https://github.com/dswah/pyGAM/blob/master/pygam/pygam.py#L290), intercept will be added at the end of self.coef_ (self.coef_[-1]) but not self.coef_[0]