### PR TITLE
Fixes #301 and some other issues

### DIFF
--- a/pygam/terms.py
+++ b/pygam/terms.py
@@ -846,7 +846,6 @@ class SplineTerm(Term):
         -------
         scipy sparse array with n rows
         """
-        X[:, self.feature][:, np.newaxis]
 
         splines = b_spline_basis(
             X[:, self.feature],


### PR DESCRIPTION
* in pygam.GAM._modelmat added selection of features, edge_knots and dtypes by term so only the necessary features are checked and features for factor terms can be set to 0 or 1 if another term is being checked
* in pygam.GAM._flatten_mesh added two lines that set by feature to 1 if not None. This fixes issue of partial dependence of tensor terms being 0 everywhere if by feature is present
* in pygam.GAM.partial_dependence removed check_X as right after it is checked in self._modelmat
* updated docstring of pygam.GAM._linear_predictor
* removed line that does nothing in terms.SplineTerm.build_column




This should fix the problem in #301 and some others that #302 might not, e.g. I believe it might break due to factor feature being set to 1.0 if it is a by feature in another term. Along the way found that by feature in tensor term is not set to 1 anywhere so partial dependence returns all 0. As _meshgrid seems to be written specifically for partial_dependence and generate_X_grid made it set by feature to 1 if not None.