### PR TITLE
fix bug where parameter callbacks is not set in LinearGAM constructor

### DIFF
--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -2461,6 +2461,7 @@ class LinearGAM(GAM):
             terms=terms,
             distribution=NormalDist(scale=self.scale),
             link='identity',
+            callbacks=callbacks,
             max_iter=max_iter,
             tol=tol,
             fit_intercept=fit_intercept,


### PR DESCRIPTION
This PR addresses a bug where the `LinearGAM` constructor does not set the parameter `callbacks`, which makes it impossible to clone an instance of `LinearGAM`.