### PR TITLE
[MNT] extend CI test matrix to ubuntu, macos, windows, python 3.9-3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,6 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
   test:
-    needs: lint
-
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Improvement Pr to CI: extends test matrix to ubuntu, macos, windows, python 3.9-3.13. Removes deprecated python 3.8 version.