### PR TITLE
[MNT] add CI concurrency exclusion for the same PR job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   code-quality:
     name: code-quality


### PR DESCRIPTION
Currently, pushing updates to a PR branch starts the PR CI anew, but it does not cancel the previous CI job.

This PR adds a concurrency limit of 1 which cancels such a previous job when the PR branch is updated.