### PR TITLE
[MNT] add missing wheels build step to `pypi.yml` release workflow

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -16,10 +16,32 @@ permissions:
   contents: read
 
 jobs:
-  deploy:
+  build_wheels:
+    name: Build wheels
+    runs-on: ubuntu-latest
 
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Build wheel
+        run: |
+          python -m pip install build
+          python -m build --wheel --sdist --outdir wheelhouse
+
+      - name: Store wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels
+          path: wheelhouse/*
+
+  deploy:
     name: Upload wheels to PyPI
     runs-on: ubuntu-latest
+    needs: build_wheels
 
     permissions:
       id-token: write


### PR DESCRIPTION
The release workflow was missing the wheels build step, this is now added.