### PR TITLE
[MNT] correct typo in package classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.9,<3.14"
 classifiers = [
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: Apache License",
+  "License :: OSI Approved :: Apache Software License",
   "Operating System :: MacOS",
   "Operating System :: Microsoft :: Windows",
   "Operating System :: Unix",
@@ -24,6 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Topic :: Scientific/Engineering",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Software Development",
 ]
 


### PR DESCRIPTION
Package classifiers must be an exact match or `pypi` upload fails.

The classifiers in https://github.com/dswah/pyGAM/pull/393 contained a typo, so will prevent upload to `pypi`.
(should be "Apache Software License" and not "Apache License")

This PR fixes the typi, and also adds the new AI classifier that I just found.

