### PR TITLE
[DOC] replace svg TeX plugin in readme by GitHub native TeX

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Make some changes and write a test...
 ## About
 Generalized Additive Models (GAMs) are smooth semi-parametric models of the form:
 
-$$g\left(\mathbb{E}\[y|X\]\right)=\beta_0+f_1(X_1)+f_2(X_2)+\dots+f_p(X_p)$$
+$$g\left(\mathbb{E}[y|X]\right)=\beta_0+f_1(X_1)+f_2(X_2)+\dots+f_p(X_p)$$
 
 where $$X = [X_1, X_2, ..., X_p]$$ are independent variables, $$y$$ is the dependent variable, and $$g$$ is a link function that relates our predictor variables to the expected value of the dependent variable.
 

--- a/README.md
+++ b/README.md
@@ -78,9 +78,11 @@ The feature functions $$f_i$$ are built using **penalized B-splines**, which all
 
 <img src=imgs/pygam_basis.png>
 
-GAMs extend generalized linear models by allowing non-linear functions of features while maintaining additivity. Since the model is additive, it is easy to examine the effect of each $$X_i$$ on $$y$$ individually while holding all other predictors constant.
+GAMs extend generalized linear models by allowing non-linear functions of features while maintaining additivity.
 
-The result is a very flexible model, where it is easy to incorporate prior knowledge and control overfitting.
+Since GAMs are additive, it is easy to examine the effect of each $$X_i$$ on $$y$$ individually while holding all other predictors constant.
+
+As a result, GAMs are a class of very flexible and interpretable models, which also make it is easy to incorporate prior knowledge and control overfitting.
 
 ## Citing pyGAM
 Please consider citing pyGAM if it has helped you in your research or work:

--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ Make some changes and write a test...
 ## About
 Generalized Additive Models (GAMs) are smooth semi-parametric models of the form:
 
-![alt tag](http://latex.codecogs.com/svg.latex?g\(\mathbb{E}\[y|X\]\)=\beta_0+f_1(X_1)+f_2(X_2)+\dots+f_p(X_p))
+$$g\left(\mathbb{E}\[y|X\]\right)=\beta_0+f_1(X_1)+f_2(X_2)+\dots+f_p(X_p)$$
 
-where `X.T = [X_1, X_2, ..., X_p]` are independent variables, `y` is the dependent variable, and `g()` is the link function that relates our predictor variables to the expected value of the dependent variable.
+where $$X = [X_1, X_2, ..., X_p]$$ are independent variables, $$y$$ is the dependent variable, and $$g$$ is a link function that relates our predictor variables to the expected value of the dependent variable.
 
-The feature functions `f_i()` are built using **penalized B splines**, which allow us to **automatically model non-linear relationships** without having to manually try out many different transformations on each variable.
+The feature functions $$f_i$$ are built using **penalized B-splines**, which allow us to **automatically model non-linear relationships** without having to manually try out many different transformations on each variable.
 
 <img src=imgs/pygam_basis.png>
 

--- a/README.md
+++ b/README.md
@@ -72,15 +72,17 @@ Generalized Additive Models (GAMs) are smooth semi-parametric models of the form
 
 $$g\left(\mathbb{E}[y|X]\right)=\beta_0+f_1(X_1)+f_2(X_2)+\dots+f_p(X_p)$$
 
-where $$X = [X_1, X_2, ..., X_p]$$ are independent variables, $$y$$ is the dependent variable, and $$g$$ is a link function that relates our predictor variables to the expected value of the dependent variable.
 
-The feature functions $$f_i$$ are built using **penalized B-splines**, which allow us to **automatically model non-linear relationships** without having to manually try out many different transformations on each variable.
+where $X = [X_1, X_2, ..., X_p]$ are independent variables, $y$ is the dependent variable, and $g$ is a link function that relates our predictor variables to the expected value of the dependent variable.
+
+
+The feature functions $f_i$ are built using **penalized B-splines**, which allow us to **automatically model non-linear relationships** without having to manually try out many different transformations on each variable.
 
 <img src=imgs/pygam_basis.png>
 
 GAMs extend generalized linear models by allowing non-linear functions of features while maintaining additivity.
 
-Since GAMs are additive, it is easy to examine the effect of each $$X_i$$ on $$y$$ individually while holding all other predictors constant.
+Since GAMs are additive, it is easy to examine the effect of each $X_i$ on $y$ individually while holding all other predictors constant.
 
 As a result, GAMs are a class of very flexible and interpretable models, which also make it is easy to incorporate prior knowledge and control overfitting.
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The feature functions $$f_i$$ are built using **penalized B-splines**, which all
 
 <img src=imgs/pygam_basis.png>
 
-GAMs extend generalized linear models by allowing non-linear functions of features while maintaining additivity. Since the model is additive, it is easy to examine the effect of each `X_i` on `Y` individually while holding all other predictors constant.
+GAMs extend generalized linear models by allowing non-linear functions of features while maintaining additivity. Since the model is additive, it is easy to examine the effect of each $$X_i$$ on $$y$$ individually while holding all other predictors constant.
 
 The result is a very flexible model, where it is easy to incorporate prior knowledge and control overfitting.
 


### PR DESCRIPTION
Replaces the TeX-via-plugin in the README by GitHub native TeX display, and uses it consistently throughout.

Also makes a minor formulation improvement at the end, point more clearly to the connection between the mathematical structure and the interpretability propertyl