### PR TITLE
[MNT] fix data packaging

### DIFF
--- a/docs/notebooks/tour_of_pygam.ipynb
+++ b/docs/notebooks/tour_of_pygam.ipynb
@@ -1100,7 +1100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -1122,8 +1122,6 @@
     }
    ],
    "source": [
-    "import numpy as np\n",
-    "\n",
     "from pygam import LinearGAM\n",
     "from pygam.datasets import mcycle\n",
     "\n",


### PR DESCRIPTION
Towards #423 - fixes data packaging by adding recursive includes for the `setuptools.datasets` config.

To test, the tests need to be run from wheels. I will add this to the CI.