### PR TITLE
[MNT] improved CI: using `uv`, and pre-release wheels test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,20 @@ jobs:
       - name: repository checkout step
         uses: actions/checkout@v4
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
       - name: python environment step
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
       - name: install pre-commit
-        run: python3 -m pip install pre-commit
+        run: uv pip install pre-commit
+        env:
+          UV_SYSTEM_PYTHON: 1
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -66,6 +73,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+
     - uses: codecov/codecov-action@v3
 
     - name: Set up Python ${{ matrix.python-version }}
@@ -74,12 +86,12 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -e ".[dev]"
+      run: pip install -e ".[dev]"
+      env:
+        UV_SYSTEM_PYTHON: 1
 
     - name: Show dependencies
-      run: python -m pip list
+      run: uv pip list
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -38,10 +38,56 @@ jobs:
           name: wheels
           path: wheelhouse/*
 
+  test_wheels:
+    needs: build_wheels
+    name: Test wheels on ${{ matrix.os }} with ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false  # to not fail all combinations if just one fail
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: wheels
+          path: wheelhouse
+
+      - name: Display downloaded artifacts
+        run: ls -l wheelhouse
+
+      # Set wheel filename differently for Unix vs Windows
+      - name: Get wheel filename (Unix)
+        if: runner.os != 'Windows'
+        run: echo "WHEELNAME=$(ls ./wheelhouse/pygam-*none-any.whl)" >> $GITHUB_ENV
+
+      - name: Get wheel filename (Windows)
+        if: runner.os == 'Windows'
+        run: echo "WHEELNAME=$(ls ./wheelhouse/pygam-*none-any.whl)" >> $env:GITHUB_ENV
+      - name: Install wheel and extras
+        run: uv pip install "${{ env.WHEELNAME }}[dev]"
+        env:
+          UV_SYSTEM_PYTHON: 1
+
+      - name: Run tests  # explicit commands as windows does not support make
+        run: python -m pytest
+
   deploy:
     name: Upload wheels to PyPI
     runs-on: ubuntu-latest
-    needs: build_wheels
+    needs: test_wheels
 
     permissions:
       id-token: write


### PR DESCRIPTION
This PR makes two improvements to the CI:

* uses `uv` for python environments throughout for speed improvements
* adds a test step prior to release, where tests are run from an install based on the packaged wheels. This solves the testing issue for #423.