### PR TITLE
Fix sklearn >=1.7 compatibility by inheriting from BaseEstimator

### DIFF
--- a/pygam/core.py
+++ b/pygam/core.py
@@ -2,6 +2,11 @@
 
 import numpy as np
 
+try:
+    from sklearn.base import BaseEstimator
+except ImportError:
+    BaseEstimator = object
+
 from pygam.utils import flatten, round_to_n_decimal_places
 
 
@@ -89,7 +94,7 @@ def nice_repr(
     return out
 
 
-class Core:
+class Core(BaseEstimator):
     """
     Creates an instance of the Core class.
 

--- a/pygam/tests/conftest.py
+++ b/pygam/tests/conftest.py
@@ -1,5 +1,14 @@
 import pytest
 
+# Configure matplotlib to use non-GUI backend before any tests import it
+# This prevents Tkinter/Tcl errors on CI environments
+try:
+    import matplotlib
+
+    matplotlib.use('Agg')
+except ImportError:
+    pass
+
 from pygam import (
     LinearGAM,
     PoissonGAM,

--- a/pygam/tests/conftest.py
+++ b/pygam/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 try:
     import matplotlib
 
-    matplotlib.use('Agg')
+    matplotlib.use("Agg")
 except ImportError:
     pass
 

--- a/pygam/tests/test_sklearn_compat.py
+++ b/pygam/tests/test_sklearn_compat.py
@@ -1,0 +1,65 @@
+"""Tests for sklearn compatibility."""
+
+import numpy as np
+import pytest
+
+from pygam import GAM, LinearGAM, LogisticGAM, PoissonGAM
+
+
+def test_gam_has_sklearn_tags():
+    """Test that GAM has __sklearn_tags__ method for sklearn 1.7+ compatibility."""
+    gam = LinearGAM()
+    assert hasattr(gam, "__sklearn_tags__"), "GAM should have __sklearn_tags__ method"
+
+
+def test_randomized_search_cv_works():
+    """Test that RandomizedSearchCV works with GAM models."""
+    try:
+        from sklearn.model_selection import RandomizedSearchCV
+    except ImportError:
+        pytest.skip("sklearn not installed")
+
+    np.random.seed(42)
+    X = np.random.randn(100, 3)
+    y = np.random.randn(100)
+
+    gam = LinearGAM()
+    param_dist = {"lam": [0.1, 0.5, 1.0]}
+
+    rs = RandomizedSearchCV(gam, param_dist, n_iter=2, cv=2, random_state=42)
+    rs.fit(X, y)
+
+    assert rs.best_params_ is not None
+    assert "lam" in rs.best_params_
+
+
+def test_grid_search_cv_works():
+    """Test that GridSearchCV works with GAM models."""
+    try:
+        from sklearn.model_selection import GridSearchCV
+    except ImportError:
+        pytest.skip("sklearn not installed")
+
+    np.random.seed(42)
+    X = np.random.randn(50, 2)
+    y = np.random.randn(50)
+
+    gam = LinearGAM()
+    param_grid = {"lam": [0.1, 1.0]}
+
+    gs = GridSearchCV(gam, param_grid, cv=2)
+    gs.fit(X, y)
+
+    assert gs.best_params_ is not None
+    assert "lam" in gs.best_params_
+
+
+def test_all_gam_types_have_sklearn_tags():
+    """Test that all GAM types have __sklearn_tags__ method."""
+    gam_types = [GAM, LinearGAM, LogisticGAM, PoissonGAM]
+
+    for gam_class in gam_types:
+        gam = gam_class()
+        assert hasattr(
+            gam, "__sklearn_tags__"
+        ), f"{gam_class.__name__} should have __sklearn_tags__ method"

--- a/pygam/tests/test_sklearn_compat.py
+++ b/pygam/tests/test_sklearn_compat.py
@@ -60,6 +60,6 @@ def test_all_gam_types_have_sklearn_tags():
 
     for gam_class in gam_types:
         gam = gam_class()
-        assert hasattr(
-            gam, "__sklearn_tags__"
-        ), f"{gam_class.__name__} should have __sklearn_tags__ method"
+        assert hasattr(gam, "__sklearn_tags__"), (
+            f"{gam_class.__name__} should have __sklearn_tags__ method"
+        )

--- a/pygam/tests/test_sklearn_compat.py
+++ b/pygam/tests/test_sklearn_compat.py
@@ -3,22 +3,27 @@
 import numpy as np
 import pytest
 
+try:
+    import sklearn
+    from sklearn.model_selection import GridSearchCV, RandomizedSearchCV
+
+    SKLEARN_INSTALLED = True
+except ImportError:
+    SKLEARN_INSTALLED = False
+
 from pygam import GAM, LinearGAM, LogisticGAM, PoissonGAM
 
 
+@pytest.mark.skipif(not SKLEARN_INSTALLED, reason="sklearn not installed")
 def test_gam_has_sklearn_tags():
     """Test that GAM has __sklearn_tags__ method for sklearn 1.7+ compatibility."""
     gam = LinearGAM()
     assert hasattr(gam, "__sklearn_tags__"), "GAM should have __sklearn_tags__ method"
 
 
+@pytest.mark.skipif(not SKLEARN_INSTALLED, reason="sklearn not installed")
 def test_randomized_search_cv_works():
     """Test that RandomizedSearchCV works with GAM models."""
-    try:
-        from sklearn.model_selection import RandomizedSearchCV
-    except ImportError:
-        pytest.skip("sklearn not installed")
-
     np.random.seed(42)
     X = np.random.randn(100, 3)
     y = np.random.randn(100)
@@ -33,13 +38,9 @@ def test_randomized_search_cv_works():
     assert "lam" in rs.best_params_
 
 
+@pytest.mark.skipif(not SKLEARN_INSTALLED, reason="sklearn not installed")
 def test_grid_search_cv_works():
     """Test that GridSearchCV works with GAM models."""
-    try:
-        from sklearn.model_selection import GridSearchCV
-    except ImportError:
-        pytest.skip("sklearn not installed")
-
     np.random.seed(42)
     X = np.random.randn(50, 2)
     y = np.random.randn(50)
@@ -54,6 +55,7 @@ def test_grid_search_cv_works():
     assert "lam" in gs.best_params_
 
 
+@pytest.mark.skipif(not SKLEARN_INSTALLED, reason="sklearn not installed")
 def test_all_gam_types_have_sklearn_tags():
     """Test that all GAM types have __sklearn_tags__ method."""
     gam_types = [GAM, LinearGAM, LogisticGAM, PoissonGAM]

--- a/pygam/tests/test_sklearn_compat.py
+++ b/pygam/tests/test_sklearn_compat.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 
 try:
-    import sklearn
     from sklearn.model_selection import GridSearchCV, RandomizedSearchCV
 
     SKLEARN_INSTALLED = True


### PR DESCRIPTION
**Phase 0 - Pre-Selection

Fixes #422

## Problem
pyGAM crashes with sklearn 1.7+ because it doesn't inherit from `BaseEstimator`, which provides the required `__sklearn_tags__` method.

## Solution
- Made `Core` class inherit from `sklearn.base.BaseEstimator`
- Added graceful fallback to `object` if sklearn not installed
- Added comprehensive tests for sklearn integration

## Testing
-  All 157 tests pass (153 existing + 4 new)
-  Verified with sklearn 1.7.2
-  Tests cover `RandomizedSearchCV` and `GridSearchCV` integration
-  Backward compatible
