### PR TITLE
[ENH] Used scipy.sparse for tensor product

### DIFF
--- a/gen_imgs.py
+++ b/gen_imgs.py
@@ -323,7 +323,6 @@ def chicago_tensor():
 
 
 def expectiles():
-
     """Generate expectiles visualization."""
     X, y = mcycle(return_X_y=True)
 

--- a/gen_imgs.py
+++ b/gen_imgs.py
@@ -1,5 +1,10 @@
 """Generate some plots for the pyGAM repo."""
 
+import matplotlib
+
+# This module is intended for generating/saving images in a headless context
+# (e.g., CI). Force a non-interactive backend to avoid GUI/Tk dependencies.
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.font_manager import FontProperties

--- a/pygam/utils.py
+++ b/pygam/utils.py
@@ -945,7 +945,7 @@ def tensor_product(a, b, reshape=True):
 
         rows = []
         for i in range(na):
-            row = sp.sparse.kron(a[i], b[i], format="csr")
+            row = sp.sparse.kron(a[i:i+1], b[i:i+1], format="csr")
             rows.append(row)
 
         return sp.sparse.vstack(rows, format="csr")

--- a/pygam/utils.py
+++ b/pygam/utils.py
@@ -945,7 +945,7 @@ def tensor_product(a, b, reshape=True):
 
         rows = []
         for i in range(na):
-            row = sp.sparse.kron(a[i:i+1], b[i:i+1], format="csr")
+            row = sp.sparse.kron(a[i : i + 1], b[i : i + 1], format="csr")
             rows.append(row)
 
         return sp.sparse.vstack(rows, format="csr")

--- a/pygam/utils.py
+++ b/pygam/utils.py
@@ -945,7 +945,7 @@ def tensor_product(a, b, reshape=True):
 
         rows = []
         for i in range(na):
-            row = sp.sparse.kron(a.getrow(i), b.getrow(i), format="csr")
+            row = sp.sparse.kron(a[i], b[i], format="csr")
             rows.append(row)
 
         return sp.sparse.vstack(rows, format="csr")


### PR DESCRIPTION
Fixes #408 

Fixed tensor_product to preserve the documented reshape behavior while keeping a sparse fast path.