### PR TITLE
Fix overflow in loglink function by clipping linear predictor values (issue #367)

### DIFF
--- a/pygam/links.py
+++ b/pygam/links.py
@@ -178,7 +178,8 @@ class LogLink(Link):
         -------
         mu : np.array of length n
         """
-        return np.exp(lp)
+        MAX_EXP = np.log(np.finfo(float).max)
+        return np.exp(np.clip(lp, -MAX_EXP, MAX_EXP))
 
     def gradient(self, mu, dist):
         """
@@ -193,6 +194,8 @@ class LogLink(Link):
         -------
         grad : np.array of length n
         """
+        eps = np.finfo(float).tiny
+        mu = np.maximum(mu, eps)
         return 1.0 / mu
 
 

--- a/pygam/tests/test_loglinks.py
+++ b/pygam/tests/test_loglinks.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+from pygam.links import LogLink
+
+
+def test_loglink_extreme_lp_no_overflow():
+    link = LogLink()
+    lp = np.array([-1000.0, 1000.0, 100000.0, -100000.0])
+
+    # Only raise on overflow inside this block
+    with np.errstate(over="raise"):
+        mu = link.mu(lp, None)
+        grad = link.gradient(mu, None)
+
+    assert np.all(np.isfinite(mu))
+    assert np.all(np.isfinite(grad))


### PR DESCRIPTION
This PR fixes a numerical overflow issue in LogLink that can occur when fitting models with extreme linear predictor values.

Problem Large or very negative linear predictor values could lead to: Overflow in np.exp(lp)
Solution: Clip the linear predictor to a safe bound before exponentiation
Testing: Added a regression test for extreme lp values. All existing tests pass
