### PR TITLE
Add tolerance intervals for LinearGAM

### DIFF
--- a/docs/notebooks/quick_start.ipynb
+++ b/docs/notebooks/quick_start.ipynb
@@ -416,6 +416,31 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Interval Estimates\n",
+    "\n",
+    "`prediction_intervals` estimate uncertainty around the expected response.  \n",
+    "`tolerance_intervals` estimate a range expected to cover a chosen fraction of future responses with a chosen confidence level.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "XX = gam.generate_X_grid(term=1)\n",
+    "prediction_intervals = gam.prediction_intervals(XX, width=0.95)\n",
+    "tolerance_intervals = gam.tolerance_intervals(\n",
+    "    XX, width=0.95, confidence=0.95, n_draws=5000\n",
+    ")\n",
+    "\n",
+    "prediction_intervals.shape, tolerance_intervals.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Partial Dependence Functions"
    ]
   },

--- a/gen_imgs.py
+++ b/gen_imgs.py
@@ -1,8 +1,12 @@
 """Generate some plots for the pyGAM repo."""
 
-import matplotlib.pyplot as plt
+import matplotlib
 import numpy as np
 from matplotlib.font_manager import FontProperties
+
+# Use a non-interactive backend for CI/headless environments.
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
 
 from pygam import GAM, ExpectileGAM, LinearGAM, LogisticGAM, PoissonGAM, f, s, te
 from pygam.datasets import (
@@ -323,7 +327,6 @@ def chicago_tensor():
 
 
 def expectiles():
-
     """Generate expectiles visualization."""
     X, y = mcycle(return_X_y=True)
 


### PR DESCRIPTION
## Summary
Adds a new `LinearGAM.tolerance_intervals(...)` API to estimate two-sided tolerance intervals.

## Details
- Added `LinearGAM.tolerance_intervals(X, width=0.95, confidence=0.95, n_draws=10000)`.
- Uses a conservative Monte Carlo approach:
  - Draw coefficients from fitted covariance.
  - Draw predictive responses.
  - Select lower/upper order statistics with Bonferroni-adjusted confidence.
- Input validation mirrors existing interval APIs (`X`, fitted-state, parameter bounds).

## Tests
Added tests in `pygam/tests/test_GAM_methods.py` for:
- fitted-model requirement
- output shape and ordering
- interval widening with larger `width` and `confidence`
- invalid argument handling

Local checks run:
- `ruff format pygam/pygam.py pygam/tests/test_GAM_methods.py`
- `ruff check pygam/pygam.py pygam/tests/test_GAM_methods.py`
- `pre-commit run --files pygam/pygam.py pygam/tests/test_GAM_methods.py`
- `pytest -q pygam/tests/test_GAM_methods.py -k "prediction_interval or tolerance_intervals"`

Closes #139