### PR TITLE
Fix p-values using Wood (2013b) rank-k truncated pseudoinverse

### DIFF
--- a/pygam/tests/test_GAM_methods.py
+++ b/pygam/tests/test_GAM_methods.py
@@ -419,18 +419,17 @@ def test_prediction_interval_known_scale():
 
 def test_pvalue_rejects_useless_feature(wage_X_y):
     """
-    check that a p-value can reject a useless feature
+    p-value for a pure-noise feature should be large (Wood 2013b formula).
     """
     X, y = wage_X_y
 
-    # add empty feature
-    X = np.c_[X, np.arange(X.shape[0])]
+    # pure-noise feature independent of y
+    rng = np.random.default_rng(42)
+    X = np.c_[X, rng.standard_normal(X.shape[0])]
     gam = LinearGAM(s(0) + s(1) + f(2) + s(3)).fit(X, y)
 
-    # now do the test, with some safety
     p_values = gam._estimate_p_values()
-    print(p_values)
-    assert p_values[-2] > 0.5  # because -1 is intercept
+    assert p_values[-2] > 0.05  # noise term; -1 is intercept
 
 
 def test_fit_quantile_is_close_enough(head_circumference_X_y):

--- a/pygam/tests/test_p_values.py
+++ b/pygam/tests/test_p_values.py
@@ -1,0 +1,101 @@
+"""Tests for Wood (2013b) p-value computation in GAM.
+
+Wood, S.N. (2013b). On p-values for smooth components of an extended
+generalized additive model. Biometrika, 100(1), 221-228.
+doi:10.1093/biomet/ass048
+"""
+
+import numpy as np
+import pytest
+
+from pygam import LinearGAM, PoissonGAM, f, s
+
+N = 500
+
+
+@pytest.fixture(scope="module")
+def linear_data():
+    rng = np.random.default_rng(0)
+    x = np.linspace(0, 6, N)
+    y = np.sin(x) + rng.normal(0, 0.3, N)
+    return x.reshape(-1, 1), y
+
+
+@pytest.fixture(scope="module")
+def linear_gam_fit(linear_data):
+    X, y = linear_data
+    return LinearGAM(s(0)).fit(X, y)
+
+
+@pytest.fixture(scope="module")
+def gam_with_noise(linear_data):
+    X, y = linear_data
+    rng = np.random.default_rng(7)
+    noise_col = rng.standard_normal(N)
+    X_ext = np.c_[X, noise_col]
+    return LinearGAM(s(0) + s(1)).fit(X_ext, y)
+
+
+class TestPValueRange:
+    def test_all_in_unit_interval(self, linear_gam_fit):
+        pvals = linear_gam_fit._estimate_p_values()
+        assert all(0.0 <= p <= 1.0 for p in pvals)
+
+    def test_returns_one_per_term(self, linear_gam_fit):
+        pvals = linear_gam_fit._estimate_p_values()
+        assert len(pvals) == len(linear_gam_fit.terms)
+
+
+class TestSignificance:
+    def test_signal_term_is_significant(self, linear_gam_fit):
+        """A spline fitted on sin(x) should have p < 0.01."""
+        pvals = linear_gam_fit._estimate_p_values()
+        assert pvals[0] < 0.01
+
+    def test_noise_term_is_not_significant(self, gam_with_noise):
+        """A pure-noise feature should not be significant at α=0.01."""
+        pvals = gam_with_noise._estimate_p_values()
+        # s(1) is the noise column; last term is intercept
+        assert pvals[1] > 0.01
+
+    def test_signal_term_survives_with_noise_column(self, gam_with_noise):
+        """Adding noise should not destroy significance of the real term."""
+        pvals = gam_with_noise._estimate_p_values()
+        assert pvals[0] < 0.01
+
+
+class TestDistributionDispatch:
+    def test_known_scale_uses_chi2_path(self, linear_data):
+        """PoissonGAM has known scale → chi2 branch."""
+        X, y = linear_data
+        y_count = np.floor(np.abs(y) * 3).astype(int) + 1
+        gam = PoissonGAM(s(0)).fit(X, y_count)
+        pvals = gam._estimate_p_values()
+        assert all(0.0 <= p <= 1.0 for p in pvals)
+        assert pvals[0] < 0.01  # sin signal still significant
+
+    def test_unknown_scale_uses_f_path(self, linear_gam_fit):
+        """LinearGAM estimates scale → F-distribution branch."""
+        assert not linear_gam_fit.distribution._known_scale
+        pvals = linear_gam_fit._estimate_p_values()
+        assert all(0.0 <= p <= 1.0 for p in pvals)
+
+
+class TestEdgeCases:
+    def test_over_parameterized_no_crash(self, linear_data):
+        """n_splines > n_samples must not raise IndexError."""
+        X, y = linear_data
+        X_small, y_small = X[:30], y[:30]
+        gam = LinearGAM(s(0, n_splines=50)).fit(X_small, y_small)
+        pvals = gam._estimate_p_values()
+        assert all(0.0 <= p <= 1.0 for p in pvals)
+
+    def test_factor_term_pvalue(self):
+        """Factor terms should produce valid p-values."""
+        rng = np.random.default_rng(1)
+        X = rng.integers(0, 5, size=(200, 1))
+        y = X[:, 0].astype(float) * 2.0 + rng.normal(0, 0.5, 200)
+        gam = LinearGAM(f(0)).fit(X, y)
+        pvals = gam._estimate_p_values()
+        assert all(0.0 <= p <= 1.0 for p in pvals)
+        assert pvals[0] < 0.01  # factor-encoded feature is informative


### PR DESCRIPTION
Replaces the Wood (2006) one-step pinv formula with the corrected approach from Wood (2013b, Biometrika 100:221-228):

- Effective rank k = round(tr(2A - A^2)) for each term's submatrix, where A = diag(U1 @ U1.T) is the hat-matrix diagonal per coefficient.
- Score uses a rank-k truncated SVD pseudoinverse of the local covariance instead of a full pinv, keeping the test statistic in the effective parameter subspace and avoiding inflation from penalised directions.
- Removes spurious mean-centering of SplineTerm coefficients before the score computation (flagged by jonathan-taylor in #163).
- Guards against zero singular values in degenerate covariance blocks.
- Removes the KNOWN BUG summary() warning that tracked this issue.

Fixes #163

Tests:
- Updates test_pvalue_rejects_useless_feature to use a true noise feature (np.random.default_rng seed=42) instead of np.arange which is actually informative.
- Adds pygam/tests/test_p_values.py with 9 new tests covering range checks, signal/noise discrimination, chi2 vs F dispatch, the over-parameterised (n_splines > n_samples) edge case, and factor terms.