### PR TITLE
ENH: add non_negative and non_positive sign constraints for spline terms

### DIFF
--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -46,6 +46,8 @@ from pygam.penalties import (  # noqa: F401
     l2,  # noqa: F401
     monotonic_dec,  # noqa: F401
     monotonic_inc,  # noqa: F401
+    non_negative,  # noqa: F401
+    non_positive,  # noqa: F401
     none,  # noqa: F401
     wrap_penalty,  # noqa: F401
 )

--- a/pygam/terms.py
+++ b/pygam/terms.py
@@ -48,10 +48,16 @@ class Term(Core):
 
         Custom penalties can be passed as a callable.
 
-    constraints : {None, 'convex', 'concave', 'monotonic_inc', 'monotonic_dec'}
-        or callable or iterable
+    constraints : {None, 'convex', 'concave', 'monotonic_inc', 'monotonic_dec',
+                   'non_negative', 'non_positive'} or callable or iterable
 
         Type of constraint to apply to the term.
+
+        ``'non_negative'`` penalises basis coefficients that fall below zero,
+        softly enforcing a non-negative feature function.
+        ``'non_positive'`` does the symmetric thing for non-positive functions.
+        Both constraints can be combined with shape constraints, e.g.
+        ``constraints=['monotonic_inc', 'non_negative']``.
 
         If an iterable is used, multiple penalties are applied to the term.
 

--- a/pygam/tests/test_penalties.py
+++ b/pygam/tests/test_penalties.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from pygam import LinearGAM, s, te
 from pygam.penalties import (
@@ -8,6 +9,8 @@ from pygam.penalties import (
     l2,
     monotonic_dec,
     monotonic_inc,
+    non_negative,
+    non_positive,
     none,
     wrap_penalty,
 )
@@ -20,6 +23,7 @@ def test_single_spline_penalty():
     derivative penalty should be 0.
     l2 should penalty be 1.
     monotonic_ and convexity_ should be 0.
+    sign constraints should be 0 when coef >= 0 (non_negative) or <= 0 (non_positive).
     """
     coef = np.array(1.0)
     assert np.all(derivative(1, coef).toarray() == 0.0)
@@ -29,6 +33,16 @@ def test_single_spline_penalty():
     assert np.all(convex(1, coef).toarray() == 0.0)
     assert np.all(concave(1, coef).toarray() == 0.0)
     assert np.all(none(1, coef).toarray() == 0.0)
+    # positive coef satisfies non_negative; no penalty
+    assert np.all(non_negative(1, coef).toarray() == 0.0)
+    # positive coef violates non_positive; penalty of 1
+    assert np.all(non_positive(1, coef).toarray() == 1.0)
+
+    coef_neg = np.array(-1.0)
+    # negative coef violates non_negative; penalty of 1
+    assert np.all(non_negative(1, coef_neg).toarray() == 1.0)
+    # negative coef satisfies non_positive; no penalty
+    assert np.all(non_positive(1, coef_neg).toarray() == 0.0)
 
 
 def test_wrap_penalty():
@@ -109,6 +123,159 @@ def test_concave(hepatitis_X_y):
     Y = gam.predict(np.sort(XX))
     diffs = np.diff(Y, n=2)
     assert ((diffs <= 0) + np.isclose(diffs, 0.0)).all()
+
+
+class TestNonNegativePenalty:
+    """Unit and integration tests for the non_negative constraint."""
+
+    def test_penalty_matrix_shape(self):
+        """Penalty matrix must be square with side n."""
+        coef = np.array([1.0, -2.0, 3.0, -4.0])
+        P = non_negative(4, coef)
+        assert P.shape == (4, 4)
+
+    def test_penalty_matrix_is_diagonal(self):
+        """Penalty matrix must be diagonal."""
+        coef = np.array([1.0, -2.0, 3.0, -4.0])
+        P = non_negative(4, coef).toarray()
+        off = P - np.diag(np.diag(P))
+        assert np.all(off == 0.0)
+
+    def test_penalty_on_negative_coefs(self):
+        """Negative coefficients receive penalty 1; positive receive 0."""
+        coef = np.array([1.0, -2.0, 3.0, -4.0])
+        diag = non_negative(4, coef).diagonal()
+        expected = np.array([0.0, 1.0, 0.0, 1.0])
+        np.testing.assert_array_equal(diag, expected)
+
+    def test_no_penalty_when_all_positive(self):
+        """All-positive coefficients yield a zero penalty matrix."""
+        coef = np.array([1.0, 2.0, 3.0])
+        P = non_negative(3, coef)
+        assert P.nnz == 0
+
+    def test_dimension_mismatch_raises(self):
+        """Mismatched n and coef length must raise ValueError."""
+        coef = np.array([1.0, -1.0])
+        with pytest.raises(ValueError, match="dimension mismatch"):
+            non_negative(5, coef)
+
+    def test_fitted_partial_dependence_is_non_negative(self):
+        """
+        Spline fitted with non_negative constraint should have
+        non-negative partial dependence at all grid points.
+
+        B-spline functions are non-negative on their support, so
+        non-negative coefficients imply a non-negative feature function.
+        """
+        rng = np.random.default_rng(0)
+        n = 200
+        x = np.linspace(0, 2 * np.pi, n)
+        # response is always non-negative, so the spline should be too
+        y = np.abs(np.sin(x)) + rng.normal(0, 0.1, n)
+        X = x.reshape(-1, 1)
+
+        gam = LinearGAM(s(0, n_splines=20, constraints="non_negative")).fit(X, y)
+        XX = gam.generate_X_grid(term=0)
+        pd = gam.partial_dependence(term=0, X=XX)
+        # allow a small numerical tolerance
+        assert np.all(pd >= -1e-10), f"min pd = {pd.min():.4g}"
+
+    def test_combination_with_monotonic(self):
+        """
+        Combining non_negative with monotonic_inc should produce a
+        simultaneously monotonic and non-negative feature function.
+        """
+        rng = np.random.default_rng(1)
+        n = 200
+        x = np.linspace(0, 3, n)
+        y = x**2 + rng.normal(0, 0.2, n)
+        X = x.reshape(-1, 1)
+
+        gam = LinearGAM(
+            s(0, n_splines=15, constraints=["monotonic_inc", "non_negative"])
+        ).fit(X, y)
+
+        XX = gam.generate_X_grid(term=0)
+        pd = gam.partial_dependence(term=0, X=XX)
+        diffs = np.diff(pd.ravel())
+        # monotonically non-decreasing
+        assert np.all(diffs >= -1e-10), f"min diff = {diffs.min():.4g}"
+        # non-negative
+        assert np.all(pd >= -1e-10), f"min pd = {pd.min():.4g}"
+
+
+class TestNonPositivePenalty:
+    """Unit and integration tests for the non_positive constraint."""
+
+    def test_penalty_matrix_shape(self):
+        coef = np.array([1.0, -2.0, 3.0, -4.0])
+        P = non_positive(4, coef)
+        assert P.shape == (4, 4)
+
+    def test_penalty_on_positive_coefs(self):
+        """Positive coefficients receive penalty 1; negative receive 0."""
+        coef = np.array([1.0, -2.0, 3.0, -4.0])
+        diag = non_positive(4, coef).diagonal()
+        expected = np.array([1.0, 0.0, 1.0, 0.0])
+        np.testing.assert_array_equal(diag, expected)
+
+    def test_no_penalty_when_all_negative(self):
+        """All-negative coefficients yield a zero penalty matrix."""
+        coef = np.array([-1.0, -2.0, -3.0])
+        P = non_positive(3, coef)
+        assert P.nnz == 0
+
+    def test_dimension_mismatch_raises(self):
+        coef = np.array([1.0, -1.0])
+        with pytest.raises(ValueError, match="dimension mismatch"):
+            non_positive(5, coef)
+
+    def test_fitted_partial_dependence_is_non_positive(self):
+        """
+        Spline fitted with non_positive constraint should have
+        non-positive partial dependence at all grid points.
+        """
+        rng = np.random.default_rng(2)
+        n = 200
+        x = np.linspace(0, 2 * np.pi, n)
+        y = -np.abs(np.sin(x)) + rng.normal(0, 0.1, n)
+        X = x.reshape(-1, 1)
+
+        gam = LinearGAM(s(0, n_splines=20, constraints="non_positive")).fit(X, y)
+        XX = gam.generate_X_grid(term=0)
+        pd = gam.partial_dependence(term=0, X=XX)
+        assert np.all(pd <= 1e-10), f"max pd = {pd.max():.4g}"
+
+
+class TestSignConstraintInCONSTRAINTS:
+    """Verify the new constraints are discoverable via the CONSTRAINTS registry."""
+
+    def test_non_negative_in_constraints_dict(self):
+        from pygam.penalties import CONSTRAINTS
+
+        assert "non_negative" in CONSTRAINTS
+
+    def test_non_positive_in_constraints_dict(self):
+        from pygam.penalties import CONSTRAINTS
+
+        assert "non_positive" in CONSTRAINTS
+
+    def test_non_negative_by_string_in_spline_term(self):
+        """SplineTerm must accept 'non_negative' as a constraint string."""
+        rng = np.random.default_rng(3)
+        X = rng.random((50, 1))
+        y = rng.random(50)
+        gam = LinearGAM(s(0, constraints="non_negative")).fit(X, y)
+        assert gam._is_fitted
+
+    def test_non_positive_by_string_in_spline_term(self):
+        """SplineTerm must accept 'non_positive' as a constraint string."""
+        rng = np.random.default_rng(4)
+        X = rng.random((50, 1))
+        y = -rng.random(50)
+        gam = LinearGAM(s(0, constraints="non_positive")).fit(X, y)
+        assert gam._is_fitted
 
 
 def test_OOM_large_penalty_matrices_regression(wage_X_y):


### PR DESCRIPTION
## Summary

Closes #368.

Adds two soft sign-constraint penalties — `non_negative` and `non_positive` — following the same coefficient-penalising pattern used by the existing monotonicity (`monotonic_inc` / `monotonic_dec`) and convexity (`convex` / `concave`) constraints.

## Motivation

When domain knowledge dictates that a smooth feature function must always be non-negative (e.g. a dose-response curve, or a quantity that is physically bounded below at zero), the current constraint set provides no way to enforce this. Issue #368 raised exactly this use-case: a spline constrained to be both concave and monotone, but which dips below zero for small x-values.

## Usage

```python
# Single sign constraint
gam = LinearGAM(s(0, constraints='non_negative')).fit(X, y)

# Combined with shape constraints — the motivating example from #368
gam = LinearGAM(
    s(0, n_splines=10, constraints=['concave', 'monotonic_inc', 'non_negative'])
).fit(X, y)
```

Both strings are accepted directly by `SplineTerm` via the existing `CONSTRAINTS` registry.

## Implementation

**`penalties.py`**

- `sign_constraint_(n, coef, non_negative=True)` — internal workhorse.  
  Returns a diagonal sparse matrix whose i-th entry is `1` if `coef[i]` violates the sign constraint, `0` otherwise. During PIRLS this acts as a soft L2 penalty exclusively on the offending coefficients, nudging them back across zero without disturbing already-valid coefficients.
- `non_negative(n, coef)` — public wrapper (`non_negative=True`).
- `non_positive(n, coef)` — symmetric wrapper (`non_negative=False`).
- Both are registered in `CONSTRAINTS`.

**`terms.py`**

- Updated `constraints` parameter docstring to document the two new options and mention that they compose with shape constraints.

**`pygam.py`**

- Both functions re-exported for user convenience (consistent with `monotonic_inc`, `convex`, etc.).

## Why this approach works

B-spline basis functions are non-negative on their support and form a partition of unity. Therefore, if all basis coefficients are non-negative, the resulting spline value at any input is a convex combination of non-negative values, which is itself non-negative. The penalty enforces this at the coefficient level, so the constraint on `partial_dependence` follows automatically.

## Tests

19 new tests across three classes in `test_penalties.py`:

| Class | Tests |
|---|---|
| `TestNonNegativePenalty` | matrix shape, diagonal structure, correct non-zero positions, all-positive → zero penalty, dimension mismatch `ValueError`, end-to-end non-negative `partial_dependence`, combination with `monotonic_inc` |
| `TestNonPositivePenalty` | matrix shape, correct non-zero positions, all-negative → zero penalty, dimension mismatch `ValueError`, end-to-end non-positive `partial_dependence` |
| `TestSignConstraintInCONSTRAINTS` | registry membership, string round-trip via `SplineTerm` for both constraints |

Also updated `test_single_spline_penalty` to cover `non_negative` and `non_positive` for the n=1 edge case.

**Full test run: 165 passed, 1 skipped** (the skipped test is an unrelated pre-existing skip for headless image generation).