### PR TITLE
Added Liu Tang Zhang Function

### DIFF
--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -87,6 +87,7 @@ from pygam.utils import (
 
 EPS = np.finfo(np.float64).eps  # machine epsilon
 
+
 def _liu_tang_zhang(q, lambdas):
     """P(sum_i lambda_i * chi2_i(1) > q) via Liu-Tang-Zhang (2009) approximation.
 
@@ -147,7 +148,6 @@ def _liu_tang_zhang(q, lambdas):
     q_norm = (q - mu_q) / sigma_q * np.sqrt(2 * l_) + l_ + delta
 
     return float(sp.stats.chi2.sf(max(q_norm, 0), df=l_))
-
 
 
 class GAM(Core, MetaTermMixin):

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -121,23 +121,23 @@ def _liu_tang_zhang(q, lambdas):
         return 1.0
 
     c1 = lambdas.sum()
-    c2 = (lambdas ** 2).sum()
-    c3 = (lambdas ** 3).sum()
-    c4 = (lambdas ** 4).sum()
+    c2 = (lambdas**2).sum()
+    c3 = (lambdas**3).sum()
+    c4 = (lambdas**4).sum()
 
     if c2 == 0:
         return 1.0
 
-    s1 = c3 / c2 ** 1.5
-    s2 = c4 / c2 ** 2
+    s1 = c3 / c2**1.5
+    s2 = c4 / c2**2
 
-    if s1 ** 2 > s2:
-        a = 1.0 / (s1 - np.sqrt(s1 ** 2 - s2))
-        delta = s1 * a ** 3 - a ** 2
-        l_ = a ** 2 - 2 * delta
+    if s1**2 > s2:
+        a = 1.0 / (s1 - np.sqrt(s1**2 - s2))
+        delta = s1 * a**3 - a**2
+        l_ = a**2 - 2 * delta
     else:
         delta = 0.0
-        l_ = c2 ** 3 / c3 ** 2 if c3 > 0 else c1 ** 2 / c2
+        l_ = c2**3 / c3**2 if c3 > 0 else c1**2 / c2
 
     if l_ <= 0:
         return 1.0

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -121,32 +121,34 @@ def _liu_tang_zhang(q, lambdas):
         return 1.0
 
     c1 = lambdas.sum()
-    c2 = (lambdas**2).sum()
-    c3 = (lambdas**3).sum()
-    c4 = (lambdas**4).sum()
+    c2 = (lambdas ** 2).sum()
+    c3 = (lambdas ** 3).sum()
+    c4 = (lambdas ** 4).sum()
 
     if c2 == 0:
         return 1.0
 
-    s1 = c3 / c2**1.5
-    s2 = c4 / c2**2
+    s1 = c3 / c2 ** 1.5
+    s2 = c4 / c2 ** 2
 
-    if s1**2 > s2:
-        a = 1.0 / (s1 - np.sqrt(s1**2 - s2))
-        delta = s1 * a**3 - a**2
-        l_ = a**2 - 2*delta
+    if s1 ** 2 > s2:
+        a = 1.0 / (s1 - np.sqrt(s1 ** 2 - s2))
+        delta = s1 * a ** 3 - a ** 2
+        l_ = a ** 2 - 2 * delta
     else:
         delta = 0.0
-        l_ = c2**3 / c3**2 if c3 > 0 else c1**2 / c2
+        l_ = c2 ** 3 / c3 ** 2 if c3 > 0 else c1 ** 2 / c2
 
     if l_ <= 0:
         return 1.0
 
     mu_q = c1
-    sigma_q = np.sqrt(2*c2)
-    q_norm = (q - mu_q) / sigma_q * np.sqrt(2*l_) + l_ + delta
+    sigma_q = np.sqrt(2 * c2)
+    q_norm = (q - mu_q) / sigma_q * np.sqrt(2 * l_) + l_ + delta
 
     return float(sp.stats.chi2.sf(max(q_norm, 0), df=l_))
+
+
 
 class GAM(Core, MetaTermMixin):
     """Generalized Additive Model.

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -87,6 +87,66 @@ from pygam.utils import (
 
 EPS = np.finfo(np.float64).eps  # machine epsilon
 
+def _liu_tang_zhang(q, lambdas):
+    """P(sum_i lambda_i * chi2_i(1) > q) via Liu-Tang-Zhang (2009) approximation.
+
+    Used for Wood (2013b) corrected p-values in penalized regression.
+    Matches the first four cumulants of the weighted chi-squared mixture
+    to a scaled chi-squared distribution and evaluates the tail probability.
+
+    Parameters
+    ----------
+    q : float
+        observed test statistic
+    lambdas : array-like
+        positive eigenvalue weights for the mixture distribution
+
+    Returns
+    -------
+    p_value : float
+
+    References
+    ----------
+    Liu, H., Tang, Y., Zhang, H.H. (2009). A new chi-square approximation
+    to the distribution of non-negative definite quadratic forms in
+    non-central normal variables. Computational Statistics & Data Analysis,
+    53(4), 853-856.
+
+    Wood, S.N. (2013b). On p-values for smooth components of an extended
+    generalized additive model. Biometrika, 100(1), 221-228.
+    """
+    lambdas = np.asarray(lambdas, dtype=float)
+    lambdas = lambdas[lambdas > 0]
+    if len(lambdas) == 0:
+        return 1.0
+
+    c1 = lambdas.sum()
+    c2 = (lambdas**2).sum()
+    c3 = (lambdas**3).sum()
+    c4 = (lambdas**4).sum()
+
+    if c2 == 0:
+        return 1.0
+
+    s1 = c3 / c2**1.5
+    s2 = c4 / c2**2
+
+    if s1**2 > s2:
+        a = 1.0 / (s1 - np.sqrt(s1**2 - s2))
+        delta = s1 * a**3 - a**2
+        l_ = a**2 - 2*delta
+    else:
+        delta = 0.0
+        l_ = c2**3 / c3**2 if c3 > 0 else c1**2 / c2
+
+    if l_ <= 0:
+        return 1.0
+
+    mu_q = c1
+    sigma_q = np.sqrt(2*c2)
+    q_norm = (q - mu_q) / sigma_q * np.sqrt(2*l_) + l_ + delta
+
+    return float(sp.stats.chi2.sf(max(q_norm, 0), df=l_))
 
 class GAM(Core, MetaTermMixin):
     """Generalized Additive Model.

--- a/pygam/tests/test_utils.py
+++ b/pygam/tests/test_utils.py
@@ -54,6 +54,7 @@ def test_liu_tang_zhang():
     5. Monotonicity: larger q => smaller p-value.
     6. Bounds: p-value must always be in [0, 1].
     """
+    import scipy as sp
     from pygam.pygam import _liu_tang_zhang
 
     # Test 1: equal weights must match chi2(k) exactly
@@ -62,16 +63,18 @@ def test_liu_tang_zhang():
         for q in [0.5, 1.0, 3.84, 6.63, 10.0]:
             ltz = _liu_tang_zhang(q, lambdas)
             exact = float(sp.stats.chi2.sf(q, df=k))
-            assert np.isclose(ltz, exact, atol=1e-10), \
+            assert np.isclose(ltz, exact, atol=1e-10), (
                 f"equal weights failed: k={k} q={q} LTZ={ltz} chi2={exact}"
+            )
 
     # Test 2: single lambda — P(lam*chi2(1) > q) = P(chi2(1) > q/lam)
     for lam in [0.1, 0.5, 1.0, 2.0, 5.0]:
         for q in [0.1, 0.5, 1.0, 2.0, 5.0]:
             ltz = _liu_tang_zhang(q, np.array([lam]))
             exact = float(sp.stats.chi2.sf(q / lam, df=1))
-            assert np.isclose(ltz, exact, atol=1e-6), \
+            assert np.isclose(ltz, exact, atol=1e-6), (
                 f"single lambda failed: lam={lam} q={q} LTZ={ltz} exact={exact}"
+            )
 
     # Test 3: mixed weights vs Monte Carlo (large n for accuracy)
     rng = np.random.default_rng(42)
@@ -84,34 +87,43 @@ def test_liu_tang_zhang():
         np.array([0.5, 0.5, 0.5, 0.5]),
     ]
     for lambdas in test_cases:
-        samples = (rng.standard_normal((n, len(lambdas)))**2) @ lambdas
+        samples = (rng.standard_normal((n, len(lambdas))) ** 2) @ lambdas
         for q in [lambdas.sum() * 0.5, lambdas.sum(), lambdas.sum() * 2.0]:
             ltz = _liu_tang_zhang(q, lambdas)
             mc = float((samples > q).mean())
-            assert abs(ltz - mc) < 0.02, \
+            assert abs(ltz - mc) < 0.02, (
                 f"MC failed: lambdas={lambdas} q={q:.3f} LTZ={ltz:.6f} MC={mc:.6f}"
+            )
 
     # Test 4: edge cases
     assert _liu_tang_zhang(1.0, np.array([])) == 1.0, "empty lambdas should return 1.0"
-    assert _liu_tang_zhang(1.0, np.array([0.0, 0.0])) == 1.0, "all-zero lambdas should return 1.0"
+    assert _liu_tang_zhang(1.0, np.array([0.0, 0.0])) == 1.0, (
+        "all-zero lambdas should return 1.0"
+    )
     assert _liu_tang_zhang(0.0, np.ones(3)) == 1.0, "q=0 should return 1.0"
-    assert _liu_tang_zhang(1e10, np.ones(3)) < 1e-10, "very large q should give ~0 p-value"
+    assert _liu_tang_zhang(1e10, np.ones(3)) < 1e-10, (
+        "very large q should give ~0 p-value"
+    )
 
     # Test 5: monotonicity — larger q must give smaller p-value
     lambdas = np.array([0.8, 0.6, 0.3])
     qs = [0.5, 1.0, 2.0, 4.0, 8.0]
     pvals = [_liu_tang_zhang(q, lambdas) for q in qs]
     for i in range(len(pvals) - 1):
-        assert pvals[i] > pvals[i+1], \
-            f"monotonicity failed at q={qs[i]}: p={pvals[i]} > p={pvals[i+1]}"
+        assert pvals[i] > pvals[i + 1], (
+            f"monotonicity failed at q={qs[i]}: p={pvals[i]} > p={pvals[i + 1]}"
+        )
 
     # Test 6: bounds — p-value must always be in [0, 1]
     for lambdas in test_cases:
         for q in [0.01, 1.0, 10.0, 100.0]:
             ltz = _liu_tang_zhang(q, lambdas)
-            assert 0.0 <= ltz <= 1.0, \
+            assert 0.0 <= ltz <= 1.0, (
                 f"bounds failed: lambdas={lambdas} q={q} LTZ={ltz}"
+            )
 
+
+            
 def test_check_y_not_int_not_float(wage_X_y, wage_gam):
     """y must be int or float, or we should get a value error"""
     X, y = wage_X_y

--- a/pygam/tests/test_utils.py
+++ b/pygam/tests/test_utils.py
@@ -43,6 +43,7 @@ def test_check_X_categorical_prediction_exceeds_training(wage_X_y, wage_gam):
     with pytest.raises(ValueError):
         gam.predict(X)
 
+
 def test_liu_tang_zhang():
     """
     Rigorous tests for _liu_tang_zhang approximation.
@@ -120,7 +121,6 @@ def test_liu_tang_zhang():
             assert 0.0 <= ltz <= 1.0, (
                 f"bounds failed: lambdas={lambdas} q={q} LTZ={ltz}"
             )
-
 
 
 def test_check_y_not_int_not_float(wage_X_y, wage_gam):

--- a/pygam/tests/test_utils.py
+++ b/pygam/tests/test_utils.py
@@ -54,7 +54,6 @@ def test_liu_tang_zhang():
     5. Monotonicity: larger q => smaller p-value.
     6. Bounds: p-value must always be in [0, 1].
     """
-    import scipy as sp
     from pygam.pygam import _liu_tang_zhang
 
     # Test 1: equal weights must match chi2(k) exactly
@@ -123,7 +122,7 @@ def test_liu_tang_zhang():
             )
 
 
-            
+
 def test_check_y_not_int_not_float(wage_X_y, wage_gam):
     """y must be int or float, or we should get a value error"""
     X, y = wage_X_y


### PR DESCRIPTION
Add Liu-Tang-Zhang (2009) weighted chi-squared p-value helper

Adds `_liu_tang_zhang`, a module-level helper that computes
P(sum_i lambda_i * chi2_i(1) > q) via the Liu-Tang-Zhang (2009)
moment-matching approximation. This is required for the Wood (2013b)
corrected p-values (issue #163), where the reference distribution is
a weighted sum of chi-squared variables rather than a plain chi2(rank).

Also adds `test_liu_tang_zhang` with rigorous tests covering equal
weights (exact chi2 match), single lambda (analytical), mixed weights
(Monte Carlo), edge cases, monotonicity, and bounds.

References
----------
Liu, H., Tang, Y., Zhang, H.H. (2009). Computational Statistics &
Data Analysis, 53(4), 853-856.

Wood, S.N. (2013b). Biometrika, 100(1), 221-228.