### PR TITLE
docs: add CONTRIBUTING.md and CODE_OF_CONDUCT.md (#437 part 1)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by opening a GitHub issue or contacting us on [Discord](https://discord.gg/Rt8By5Jj). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,124 @@
+# Contributing to pyGAM
+
+First off, thanks for taking the time to contribute! All types of contributions are encouraged and valued.
+
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [Getting Started](#getting-started)
+- [How to Contribute](#how-to-contribute)
+- [Development Setup](#development-setup)
+- [Pull Request Process](#pull-request-process)
+- [Coding Standards](#coding-standards)
+- [Testing](#testing)
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by the [pyGAM Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+
+## Getting Started
+
+- Join our [Discord](https://discord.gg/Rt8By5Jj) for discussions and updates
+- Check out the [documentation](https://pygam.readthedocs.io/en/latest/)
+- Look at [open issues](https://github.com/dswah/pyGAM/issues) for ways to help
+
+## How to Contribute
+
+### Reporting Bugs
+
+Before creating bug reports, please check the existing issues to avoid duplicates. When creating a bug report, include:
+
+- A clear and descriptive title
+- Steps to reproduce the problem
+- Expected behavior vs actual behavior
+- Your Python version and operating system
+- Any relevant code snippets or error messages
+
+### Suggesting Enhancements
+
+Enhancement suggestions are welcome! Please include:
+
+- A clear description of the enhancement
+- Why this would be useful to pyGAM users
+- Any examples of similar features in other packages
+
+### Working on Issues
+
+Look for issues labeled:
+- `good first issue` - good for newcomers
+- `bug` - something isn't working
+- `enhancement` - new feature or request
+- `help wanted` - extra attention is needed
+
+## Development Setup
+
+1. Fork the repository on GitHub
+2. Clone your fork locally:
+   ```bash
+   git clone https://github.com/YOUR_USERNAME/pyGAM.git
+   cd pyGAM
+   ```
+3. Create a virtual environment:
+   ```bash
+   python -m venv venv
+   source venv/bin/activate  # On Windows: venv\Scripts\activate
+   ```
+4. Install development dependencies:
+   ```bash
+   pip install --upgrade pip
+   pip install -e ".[dev]"
+   ```
+
+## Pull Request Process
+
+1. Create a new branch from `main`:
+   ```bash
+   git checkout -b your-feature-name
+   ```
+
+2. Make your changes, following our coding standards
+
+3. Add or update tests as needed
+
+4. Run the test suite:
+   ```bash
+   pytest
+   ```
+
+5. Commit your changes with a descriptive message:
+   ```bash
+   git commit -m "Description of your changes"
+   ```
+
+6. Push to your fork and submit a pull request to the `main` branch
+
+7. Ensure all CI checks pass
+
+## Coding Standards
+
+- Follow PEP 8 style guidelines
+- Use meaningful variable and function names
+- Add docstrings to all public functions and classes
+- Keep functions focused and modular
+- Write code comments for complex logic
+
+## Testing
+
+- All new features should include tests
+- Bug fixes should include regression tests
+- Run tests before submitting a PR:
+  ```bash
+  pytest
+  ```
+- For specific test files:
+  ```bash
+  pytest pygam/tests/test_your_file.py
+  ```
+
+## Questions?
+
+Feel free to:
+- Open an issue for questions
+- Join our [Discord](https://discord.gg/Rt8By5Jj) for discussions
+
+Thank you for contributing to pyGAM!

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ pip install numpy scipy --extra-index-url https://urob.github.io/numpy-mkl
 ```
 
 ## Contributing - HELP REQUESTED
-Contributions are most welcome!
+
+Contributions are most welcome! Please read our [Contributing Guide](CONTRIBUTING.md) for details on how to get started.
 
 You can help pyGAM in many ways including:
 


### PR DESCRIPTION
This PR adds \CONTRIBUTING.md\ and \CODE_OF_CONDUCT.md\ to streamline contributions and set clear community standards. Extracted from the original PR #437 as requested by the maintainer. cc @dswah