### PR TITLE
feat: n_jobs parameter in gridsearch for parallelism (#437 part 3)

### DIFF
--- a/pygam/tests/test_gridsearch.py
+++ b/pygam/tests/test_gridsearch.py
@@ -266,3 +266,17 @@ def test_gridsearch_works_on_Series_REGRESSION():
     # Series
     gam = LinearGAM().gridsearch(X[0], y)
     assert gam._is_fitted
+
+
+def test_gridsearch_n_jobs(mcycle_X_y):
+    """
+    check that gridsearch with n_jobs!=1 produces the same best model as n_jobs=1
+    and does not fail.
+    """
+    X, y = mcycle_X_y
+    gam_seq = LinearGAM().gridsearch(X, y, lam=np.logspace(-3, 3, 5), n_jobs=1)
+    gam_par = LinearGAM().gridsearch(X, y, lam=np.logspace(-3, 3, 5), n_jobs=-1)
+
+    assert gam_seq._is_fitted
+    assert gam_par._is_fitted
+    assert np.allclose(gam_seq.coef_, gam_par.coef_)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
+    "joblib>=1.1.1",
     "numpy>=1.5.0",
     "progressbar2>=4.2.0,<5",
     "scipy>=1.11.1,<1.17",


### PR DESCRIPTION
This PR adds \joblib\ parallelism support via the \
_jobs\ parameter to the \gridsearch\ method, significantly speeding up hyperparameter tuning for large grids, along with their respective tests. Extracted from the original PR #437 as requested by the maintainer. cc @dswah