### PR TITLE
[ENH] allow GAM.summary() output to be returned as string or written to file

### DIFF
--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -1,8 +1,8 @@
 """pyGAM Model Clases"""
 
-import warnings
 import io
 import sys
+import warnings
 from collections import OrderedDict, defaultdict
 from copy import deepcopy
 
@@ -1803,19 +1803,22 @@ class GAM(Core, MetaTermMixin):
         print("=" * 106, file=target_file)
         print(TablePrinter(fmt, ul="=")(data), file=target_file)
         print("=" * 106, file=target_file)
-        print("Significance codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1", file=target_file)
+        print(
+            "Significance codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1",
+            file=target_file,
+        )
         print(file=target_file)
         print(
             "WARNING: Fitting splines and a linear function to a feature introduces a model identifiability problem\n"  # noqa: E501
             "         which can cause p-values to appear significant when they are not.",
-            file=target_file
+            file=target_file,
         )
         print(file=target_file)
         print(
             "WARNING: p-values calculated in this manner behave correctly for un-penalized models or models with\n"  # noqa: E501
             "         known smoothing parameters, but when smoothing parameters have been estimated, the p-values\n"  # noqa: E501
             "         are typically lower than they should be, meaning that the tests reject the null too readily.",  # noqa: E501
-            file=target_file
+            file=target_file,
         )
 
         # P-VALUE BUG

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -1,6 +1,8 @@
 """pyGAM Model Clases"""
 
 import warnings
+import io
+import sys
 from collections import OrderedDict, defaultdict
 from copy import deepcopy
 
@@ -1642,15 +1644,34 @@ class GAM(Core, MetaTermMixin):
 
         return out[0]
 
-    def summary(self):
+    def summary(self, return_str=False, file=None):
         """Produce a summary of the model statistics.
+
+        Parameters
+        ----------
+        return_str : bool, default: False
+            whether to return the summary as a string
+        file : file-like, default: None
+            file-like object to write the summary to.
+            if None, defaults to sys.stdout (via print default)
 
         Returns
         -------
-        None
+        summary_str : str or None
+            if return_str is True, returns the summary as a string.
+            otherwise returns None.
         """
         if not self._is_fitted:
             raise AttributeError("GAM has not been fitted. Call fit first.")
+
+        capture_buffer = None
+        if return_str:
+            capture_buffer = io.StringIO()
+            target_file = capture_buffer
+        elif file is not None:
+            target_file = file
+        else:
+            target_file = sys.stdout
 
         # high-level model summary
         width_details = 47
@@ -1778,21 +1799,23 @@ class GAM(Core, MetaTermMixin):
             ("Sig. Code", "sig_code", 12),
         ]
 
-        print(TablePrinter(model_fmt, ul="=", sep=" ")(model_details))
-        print("=" * 106)
-        print(TablePrinter(fmt, ul="=")(data))
-        print("=" * 106)
-        print("Significance codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1")
-        print()
+        print(TablePrinter(model_fmt, ul="=", sep=" ")(model_details), file=target_file)
+        print("=" * 106, file=target_file)
+        print(TablePrinter(fmt, ul="=")(data), file=target_file)
+        print("=" * 106, file=target_file)
+        print("Significance codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1", file=target_file)
+        print(file=target_file)
         print(
             "WARNING: Fitting splines and a linear function to a feature introduces a model identifiability problem\n"  # noqa: E501
-            "         which can cause p-values to appear significant when they are not."
+            "         which can cause p-values to appear significant when they are not.",
+            file=target_file
         )
-        print()
+        print(file=target_file)
         print(
             "WARNING: p-values calculated in this manner behave correctly for un-penalized models or models with\n"  # noqa: E501
             "         known smoothing parameters, but when smoothing parameters have been estimated, the p-values\n"  # noqa: E501
-            "         are typically lower than they should be, meaning that the tests reject the null too readily."  # noqa: E501
+            "         are typically lower than they should be, meaning that the tests reject the null too readily.",  # noqa: E501
+            file=target_file
         )
 
         # P-VALUE BUG
@@ -1804,6 +1827,9 @@ class GAM(Core, MetaTermMixin):
             "github.com/dswah/pyGAM/issues/163 \n",
             stacklevel=2,
         )
+
+        if return_str:
+            return capture_buffer.getvalue()
 
     def gridsearch(
         self,

--- a/pygam/tests/test_GAM_methods.py
+++ b/pygam/tests/test_GAM_methods.py
@@ -1,5 +1,5 @@
-import sys
 import io
+import sys
 
 import numpy as np
 import pytest


### PR DESCRIPTION
## ENH: support capturing `GAM.summary()` output via `return_str` or `file` parameter (closes #316)

## Summary

This PR addresses #316 by adding optional `return_str` and `file` parameters to `GAM.summary()`.

These additions allow users to:

- Capture the model summary as a string variable (`return_str=True`)
- Redirect the output to a file-like object (`file=...`)
- Preserve the existing default behavior (printing to stdout)

This enhancement removes the need for manual `stdout` redirection workarounds while maintaining full backward compatibility.

---

## Changes

### Core Logic (`pygam/pygam.py`)

- Added `import io` and `import sys` to support output capturing and explicit stdout fallback.
- Updated `GAM.summary()` signature to:

  ```python
  def summary(self, return_str=False, file=None)
  ```

- Introduced `target_file` routing logic:

  - If `return_str=True`, output is captured using an `io.StringIO` buffer and returned as a string.
  - If `file` is provided, output is written directly to that file-like object.
  - If neither is specified, output defaults to `sys.stdout`, preserving existing behavior.

- Updated all internal `print()` calls to use `file=target_file`.

Backward compatibility is fully preserved, existing calls to `summary()` without arguments behave exactly as before.

---

### Tests (`pygam/tests/test_GAM_methods.py`)

Added:

- `test_summary_return_str`
  - Verifies that `summary(return_str=True)` returns a string containing expected content.

- `test_summary_file`
  - Verifies that `summary(file=...)` writes output to a provided buffer.

- `test_summary_both_params`
  - Verifies deterministic behavior when both parameters are supplied.

Tests assert on meaningful substrings (e.g., `"LinearGAM"`, `"Effective DoF"`) rather than rigid line counts to improve resilience.

---

## Behavior Summary

| Usage | Behavior |
|-------|----------|
| `gam.summary()` | Prints to stdout (unchanged) |
| `gam.summary(return_str=True)` | Returns summary as string |
| `gam.summary(file=f)` | Writes summary to file-like object |
| `gam.summary(return_str=True, file=f)` | Returns string (`return_str` takes precedence) |

---