### PR TITLE
Minimum Smoothening Parameter bounds with H matrix

### DIFF
--- a/gen_imgs.py
+++ b/gen_imgs.py
@@ -323,7 +323,6 @@ def chicago_tensor():
 
 
 def expectiles():
-
     """Generate expectiles visualization."""
     X, y = mcycle(return_X_y=True)
 

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -560,7 +560,8 @@ class GAM(Core, MetaTermMixin):
     
     def _H(self):
         """Minimum penalty matrix H (Wood, 2006 pg 177).
-        Enforces lower bounds on smoothing: H = sum_i lam_min_i * S_i"""
+        Enforces lower bounds on smoothing: H = sum_i lam_min_i * S_i
+        """
         return self.terms.build_minimum_penalties()
 
     def _C(self):
@@ -752,7 +753,7 @@ class GAM(Core, MetaTermMixin):
 
         P = self._P()
         S = sp.sparse.diags(np.ones(m) * np.sqrt(EPS))  # improve condition
-        S += self._H() # enforce lower bound on smoothening, S.N. Woods
+        S += self._H()  # enforce lower bound on smoothening, S.N. Woods
 
         # if we don't have any constraints, then do cholesky now
         if not self.terms.hasconstraint:

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -557,6 +557,11 @@ class GAM(Core, MetaTermMixin):
 
         """
         return self.terms.build_penalties()
+    
+    def _H(self):
+        """Minimum penalty matrix H (Wood, 2006 pg 177).
+        Enforces lower bounds on smoothing: H = sum_i lam_min_i * S_i"""
+        return self.terms.build_minimum_penalties()
 
     def _C(self):
         """
@@ -747,7 +752,7 @@ class GAM(Core, MetaTermMixin):
 
         P = self._P()
         S = sp.sparse.diags(np.ones(m) * np.sqrt(EPS))  # improve condition
-        # S += self._H # add any user-chosen minimum penalty to the diagonal
+        S += self._H() # enforce lower bound on smoothening, S.N. Woods
 
         # if we don't have any constraints, then do cholesky now
         if not self.terms.hasconstraint:

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -557,7 +557,7 @@ class GAM(Core, MetaTermMixin):
 
         """
         return self.terms.build_penalties()
-    
+
     def _H(self):
         """Minimum penalty matrix H (Wood, 2006 pg 177).
         Enforces lower bounds on smoothing: H = sum_i lam_min_i * S_i

--- a/pygam/terms.py
+++ b/pygam/terms.py
@@ -198,6 +198,7 @@ class Term(Core):
                 f"expected 1 lam per penalty, but found lam = {self.lam}, penalties = {self.penalties}"
             )
         
+        
         # check lam_min and distribute to penalties
         if not isiterable(self.lam_min):
             self.lam_min = [self.lam_min]
@@ -365,6 +366,7 @@ class Term(Core):
             Ps.append(np.multiply(P, lam))
         return np.sum(Ps)
     
+
     def build_minimum_penalties(self, verbose=False):
         if self.isintercept:
             return np.array([[0.0]])
@@ -372,10 +374,15 @@ class Term(Core):
         for penalty, lam_min in zip(self.penalties, self.lam_min):
             # same penalty-resolution logic as build_penalties
             if penalty == "auto":
-                penalty = "periodic" if getattr(self, "basis", None) == "cp" else "derivative"
-                if self.dtype == "categorical": penalty = "l2"
-            if penalty is None: penalty = "none"
-            if penalty in PENALTIES: penalty = PENALTIES[penalty]
+                penalty = (
+                    "periodic" if getattr(self, "basis", None) == "cp" else "derivative"
+                )
+                if self.dtype == "categorical": 
+                    penalty = "l2"
+            if penalty is None: 
+                penalty = "none"
+            if penalty in PENALTIES: 
+                penalty = PENALTIES[penalty]
             Ps.append(np.multiply(penalty(self.n_coefs, coef=None), lam_min))
         return np.sum(Ps)
 
@@ -678,7 +685,7 @@ class LinearTerm(Term):
         contains dict with the sufficient information to duplicate the term
     """
 
-    def __init__(self, feature, lam=0.6, lam_min=0,penalties="auto", verbose=False):
+    def __init__(self, feature, lam=0.6, lam_min=0, penalties="auto", verbose=False):
         self._name = "linear_term"
         self._minimal_name = "l"
         super(LinearTerm, self).__init__(
@@ -1044,7 +1051,13 @@ class FactorTerm(SplineTerm):
     _encodings = ["one-hot", "dummy"]
 
     def __init__(
-        self, feature, lam=0.6, lam_min=0,penalties="auto", coding="one-hot", verbose=False
+        self,
+        feature,
+        lam=0.6,
+        lam_min=0,
+        penalties="auto",
+        coding="one-hot",
+        verbose=False
     ):
         self.coding = coding
         super(FactorTerm, self).__init__(
@@ -2000,6 +2013,7 @@ class TermList(Core, MetaTermMixin):
         for term in self._terms:
             P.append(term.build_penalties())
         return sp.sparse.block_diag(P).tocsc()
+    
     
     def build_minimum_penalties(self):
         """

--- a/pygam/terms.py
+++ b/pygam/terms.py
@@ -197,8 +197,7 @@ class Term(Core):
             raise ValueError(
                 f"expected 1 lam per penalty, but found lam = {self.lam}, penalties = {self.penalties}"
             )
-        
-        
+
         # check lam_min and distribute to penalties
         if not isiterable(self.lam_min):
             self.lam_min = [self.lam_min]
@@ -212,8 +211,8 @@ class Term(Core):
         if len(self.lam_min) != len(self.penalties):
             raise ValueError(
                 f"expected 1 lam_min per penalty, but found lam_min={self.lam_min}"
-                )
-        
+            )
+
         # constraints
         if not isiterable(self.constraints):
             self.constraints = [self.constraints]
@@ -365,7 +364,6 @@ class Term(Core):
             P = penalty(self.n_coefs, coef=None)  # penalties dont need coef
             Ps.append(np.multiply(P, lam))
         return np.sum(Ps)
-    
 
     def build_minimum_penalties(self, verbose=False):
         if self.isintercept:
@@ -377,11 +375,11 @@ class Term(Core):
                 penalty = (
                     "periodic" if getattr(self, "basis", None) == "cp" else "derivative"
                 )
-                if self.dtype == "categorical": 
+                if self.dtype == "categorical":
                     penalty = "l2"
-            if penalty is None: 
+            if penalty is None:
                 penalty = "none"
-            if penalty in PENALTIES: 
+            if penalty in PENALTIES:
                 penalty = PENALTIES[penalty]
             Ps.append(np.multiply(penalty(self.n_coefs, coef=None), lam_min))
         return np.sum(Ps)
@@ -691,7 +689,7 @@ class LinearTerm(Term):
         super(LinearTerm, self).__init__(
             feature=feature,
             lam=lam,
-            lam_min=lam_min,    
+            lam_min=lam_min,
             penalties=penalties,
             constraints=None,
             dtype="numerical",
@@ -1057,7 +1055,7 @@ class FactorTerm(SplineTerm):
         lam_min=0,
         penalties="auto",
         coding="one-hot",
-        verbose=False
+        verbose=False,
     ):
         self.coding = coding
         super(FactorTerm, self).__init__(
@@ -1565,7 +1563,7 @@ class TensorTerm(SplineTerm, MetaTermMixin):
                 P_total = sp.sparse.kron(P_total, P)
 
         return P_total
-    
+
     def build_minimum_penalties(self):
         P = sp.sparse.coo_array((self.n_coefs, self.n_coefs))
         for i in range(len(self._terms)):
@@ -2013,8 +2011,7 @@ class TermList(Core, MetaTermMixin):
         for term in self._terms:
             P.append(term.build_penalties())
         return sp.sparse.block_diag(P).tocsc()
-    
-    
+
     def build_minimum_penalties(self):
         """
         Similar to build_penalties, but builds the minimum penalty matrix for each term.


### PR DESCRIPTION
The _P() Method already builds a lam * P matrix for each term. For the H matrix ( lower bounds on smoothening, we code a function build_minimum_penalties similar to build_penalties, which uses a new parameter lam_min (default 0) instead of lam. This term lam_min is added to every Term and __init__ function, and is used to build the H matrix, using the _H() function. Previously, a snippet in line 750 already asks us to add the H matrix. Now, it is implemented as a function H, which returns the matrix, therefore it is changed to S += self._H(). This simple change enables us to add a minimum smoothening bound and now enforces it in the form:

GAM(s(0, lam_min=0.1) + s(1, lam_min=10)).fit(X, y)
enforces λ₁ ≥ 0.1, λ₂ ≥ 10

Closes #26 