### PR TITLE
Fix: Support for Scikit-Learn v1.7+ Compatibility (#422)

### DIFF
--- a/gen_imgs.py
+++ b/gen_imgs.py
@@ -323,7 +323,6 @@ def chicago_tensor():
 
 
 def expectiles():
-
     """Generate expectiles visualization."""
     X, y = mcycle(return_X_y=True)
 

--- a/pygam/core.py
+++ b/pygam/core.py
@@ -2,6 +2,12 @@
 
 import numpy as np
 
+try:
+    from sklearn.base import BaseEstimator
+except ImportError:
+    class BaseEstimator(object):
+        pass
+
 from pygam.utils import flatten, round_to_n_decimal_places
 
 
@@ -89,7 +95,7 @@ def nice_repr(
     return out
 
 
-class Core:
+class Core(BaseEstimator):
     """
     Creates an instance of the Core class.
 

--- a/pygam/core.py
+++ b/pygam/core.py
@@ -5,8 +5,10 @@ import numpy as np
 try:
     from sklearn.base import BaseEstimator
 except ImportError:
-    class BaseEstimator(object):
+
+    class BaseEstimator:
         pass
+
 
 from pygam.utils import flatten, round_to_n_decimal_places
 

--- a/pygam/tests/test_sklearn_compatibility.py
+++ b/pygam/tests/test_sklearn_compatibility.py
@@ -1,8 +1,12 @@
-import pytest
 import numpy as np
+import pytest
+
 from pygam import GAM
+
+pytest.importorskip("sklearn")
+from sklearn.metrics import make_scorer, r2_score
 from sklearn.model_selection import KFold, RandomizedSearchCV
-from sklearn.metrics import r2_score, make_scorer
+
 
 def test_sklearn_compatibility_randomized_search():
     """
@@ -22,8 +26,8 @@ def test_sklearn_compatibility_randomized_search():
         scoring=scorer,
         verbose=0,
     )
-    
+
     # This will raise an AttributeError if __sklearn_tags__ or BaseEstimator is missing
     random_search.fit(X, y)
-    
+
     assert hasattr(random_search, "best_estimator_")

--- a/pygam/tests/test_sklearn_compatibility.py
+++ b/pygam/tests/test_sklearn_compatibility.py
@@ -1,0 +1,29 @@
+import pytest
+import numpy as np
+from pygam import GAM
+from sklearn.model_selection import KFold, RandomizedSearchCV
+from sklearn.metrics import r2_score, make_scorer
+
+def test_sklearn_compatibility_randomized_search():
+    """
+    Test that pyGAM models can be used with Scikit-Learn's RandomizedSearchCV.
+    This explicitly tests for the presence of Scikit-Learn 1.6+ __sklearn_tags__
+    support through BaseEstimator inheritance.
+    """
+    X = np.random.rand(50, 2)
+    y = np.random.rand(50)
+
+    scorer = make_scorer(r2_score, greater_is_better=True)
+    random_search = RandomizedSearchCV(
+        GAM(),
+        cv=KFold(n_splits=2),
+        param_distributions={"n_splines": [5, 10]},
+        n_iter=1,
+        scoring=scorer,
+        verbose=0,
+    )
+    
+    # This will raise an AttributeError if __sklearn_tags__ or BaseEstimator is missing
+    random_search.fit(X, y)
+    
+    assert hasattr(random_search, "best_estimator_")


### PR DESCRIPTION
This commit resolves an issue where PyGAM models cause an AttributeError in Scikit-learn >= 1.6 and 1.7+ due to a missing __sklearn_tags__ attribute. By making the Core class optionally inherit from sklearn.base.BaseEstimator, the necessary estimator tags are automatically provided by Scikit-Learn, allowing seamless integration with meta-estimators like RandomizedSearchCV. Added test_sklearn_compatibility.py to ensure long-term validation.