### PR TITLE
FIX: sklearn clone() returns empty terms list (#340)

### DIFF
--- a/gen_imgs.py
+++ b/gen_imgs.py
@@ -323,7 +323,6 @@ def chicago_tensor():
 
 
 def expectiles():
-
     """Generate expectiles visualization."""
     X, y = mcycle(return_X_y=True)
 

--- a/pygam/terms.py
+++ b/pygam/terms.py
@@ -114,6 +114,7 @@ class Term(Core):
     def __sklearn_clone__(self):
         # Prevent sklearn.clone() from duck-typing Term as an estimator
         from copy import deepcopy
+
         return deepcopy(self)
 
     def __len__(self):
@@ -1675,6 +1676,7 @@ class TermList(Core, MetaTermMixin):
     def __sklearn_clone__(self):
         # Prevent sklearn.clone() from duck-typing TermList as an estimator
         from copy import deepcopy
+
         return deepcopy(self)
 
     def __init__(self, *terms, **kwargs):

--- a/pygam/terms.py
+++ b/pygam/terms.py
@@ -111,6 +111,11 @@ class Term(Core):
         super(Term, self).__init__(name=self._name)
         self._validate_arguments()
 
+    def __sklearn_clone__(self):
+        # Prevent sklearn.clone() from duck-typing Term as an estimator
+        from copy import deepcopy
+        return deepcopy(self)
+
     def __len__(self):
         return 1
 
@@ -1666,6 +1671,11 @@ class TermList(Core, MetaTermMixin):
     """
 
     _terms = []
+
+    def __sklearn_clone__(self):
+        # Prevent sklearn.clone() from duck-typing TermList as an estimator
+        from copy import deepcopy
+        return deepcopy(self)
 
     def __init__(self, *terms, **kwargs):
         super(TermList, self).__init__()

--- a/pygam/tests/test_issue_340_sklearn_clone.py
+++ b/pygam/tests/test_issue_340_sklearn_clone.py
@@ -1,8 +1,14 @@
 import pytest
 import numpy as np
+
+# Skip this entire test module if scikit-learn is not installed
+pytest.importorskip("sklearn")
+
 from sklearn.base import clone
-from pygam import LinearGAM, LogisticGAM, PoissonGAM
-from pygam.terms import s, l
+
+from pygam import LinearGAM, LogisticGAM
+from pygam.terms import l, s
+
 
 def test_sklearn_clone_preserves_terms():
     """
@@ -17,13 +23,13 @@ def test_sklearn_clone_preserves_terms():
     gam1 = LinearGAM()
     gam1.fit(X, y)
     gam1_cloned = clone(gam1)
-    
+
     # After cloning, the new instance should have the original string 'auto' terms,
     # NOT a resolved TermList, and should NOT be fitted.
     assert hasattr(gam1_cloned, "terms")
     assert gam1_cloned.terms == "auto"
     assert not gam1_cloned._is_fitted
-    
+
     # It should be fitable and match original predictions closely
     gam1_cloned.fit(X, y)
     assert np.allclose(gam1.predict(X), gam1_cloned.predict(X))
@@ -33,16 +39,16 @@ def test_sklearn_clone_preserves_terms():
     gam2 = LinearGAM(custom_terms)
     gam2.fit(X, y)
     gam2_cloned = clone(gam2)
-    
+
     # After cloning, terms should be the original TermList passed in
     assert repr(gam2_cloned.terms) == repr(custom_terms)
-    
+
     # Test 3: LogisticGAM with binary target
     y_bin = (y > 0.5).astype(float)
     gam3 = LogisticGAM()
     gam3.fit(X, y_bin)
     gam3_cloned = clone(gam3)
-    
+
     assert gam3_cloned.terms == "auto"
     gam3_cloned.fit(X, y_bin)
     assert np.allclose(gam3.predict(X), gam3_cloned.predict(X))

--- a/pygam/tests/test_issue_340_sklearn_clone.py
+++ b/pygam/tests/test_issue_340_sklearn_clone.py
@@ -1,5 +1,5 @@
-import pytest
 import numpy as np
+import pytest
 
 # Skip this entire test module if scikit-learn is not installed
 pytest.importorskip("sklearn")

--- a/pygam/tests/test_issue_340_sklearn_clone.py
+++ b/pygam/tests/test_issue_340_sklearn_clone.py
@@ -1,0 +1,48 @@
+import pytest
+import numpy as np
+from sklearn.base import clone
+from pygam import LinearGAM, LogisticGAM, PoissonGAM
+from pygam.terms import s, l
+
+def test_sklearn_clone_preserves_terms():
+    """
+    Test that sklearn.base.clone() properly reconstructs a pyGAM estimator
+    and preserves its terms, even after it has been fully fitted.
+    See: https://github.com/dswah/pyGAM/issues/340
+    """
+    X = np.random.rand(50, 3)
+    y = np.random.rand(50)
+
+    # Test 1: LinearGAM with default string terms ('auto')
+    gam1 = LinearGAM()
+    gam1.fit(X, y)
+    gam1_cloned = clone(gam1)
+    
+    # After cloning, the new instance should have the original string 'auto' terms,
+    # NOT a resolved TermList, and should NOT be fitted.
+    assert hasattr(gam1_cloned, "terms")
+    assert gam1_cloned.terms == "auto"
+    assert not gam1_cloned._is_fitted
+    
+    # It should be fitable and match original predictions closely
+    gam1_cloned.fit(X, y)
+    assert np.allclose(gam1.predict(X), gam1_cloned.predict(X))
+
+    # Test 2: LinearGAM with custom TermList
+    custom_terms = s(0) + l(1) + s(2, n_splines=20)
+    gam2 = LinearGAM(custom_terms)
+    gam2.fit(X, y)
+    gam2_cloned = clone(gam2)
+    
+    # After cloning, terms should be the original TermList passed in
+    assert repr(gam2_cloned.terms) == repr(custom_terms)
+    
+    # Test 3: LogisticGAM with binary target
+    y_bin = (y > 0.5).astype(float)
+    gam3 = LogisticGAM()
+    gam3.fit(X, y_bin)
+    gam3_cloned = clone(gam3)
+    
+    assert gam3_cloned.terms == "auto"
+    gam3_cloned.fit(X, y_bin)
+    assert np.allclose(gam3.predict(X), gam3_cloned.predict(X))


### PR DESCRIPTION
Fix `sklearn.clone()` returning empty terms list on fitted GAMs (#340)

### Description
This PR resolves an issue where calling `sklearn.base.clone(gam)` on a fitted GAM estimator results in an identical estimator but with a missing `terms` list (`gam.terms == ""`), breaking Scikit-Learn workflows (like grid search and cross-validation) that rely on cloning properly passing initialization arguments.

**Root cause:** 
`GAM.fit()` mutates string configurations like `terms='auto'` into `TermList` objects in-place. Because `sklearn.clone()` queries `get_params(deep=False)`, it received the mutated state rather than original initialization parameters, and then additionally tried to deep clone the `TermList` dynamically because it inherits `Core.get_params()`, resulting in parameter destruction.

**Changes:**
- **Store Initial Values:** `GAM.fit()` now stores `_init_distribution`, `_init_link`, `_init_callbacks`, and `_init_terms` before applying data-dependent validation.
- **Selective `get_params()` Override:** `GAM.get_params(deep=False)` now explicitly restores the original instantiation parameters so `clone()` receives correct input, cleanly segregating scikit-learn requirements from pyGAM's internal `keep_best` `deep=True` routines.
- **Bypass duck-typing:** Custom `__sklearn_clone__` implemented on `Term` and `TermList` to explicitly force `copy.deepcopy` and prevent `sklearn.clone` from attempting to reconstruct them as empty nested estimators.
- **Internal Optimization:** Removed redundant, harmful `set_params()` calls in `_bootstrap_samples_of_smoothing` and `gridsearch` that broke identically.
- **Testing:** Comprehensive regression test `test_sklearn_clone_preserves_terms` guarantees functionality safely across LinearGAM/LogisticGAM and customized parameters.
