### PR TITLE
feat:allow random effect in spline term 

### DIFF
--- a/gen_imgs.py
+++ b/gen_imgs.py
@@ -323,7 +323,6 @@ def chicago_tensor():
 
 
 def expectiles():
-
     """Generate expectiles visualization."""
     X, y = mcycle(return_X_y=True)
 

--- a/pygam/terms.py
+++ b/pygam/terms.py
@@ -1999,6 +1999,7 @@ def s(
     constraints=None,
     dtype="numerical",
     basis="ps",
+    bs=None,
     by=None,
     edge_knots=None,
     verbose=False,
@@ -2009,6 +2010,49 @@ def s(
     --------
     SplineTerm : for developer details
     """
+    if bs is not None:
+        if bs not in ["ps", "cp", "re"]:
+            raise ValueError("bs must be one of ['ps', 'cp', 're']")
+
+        if bs == "re":
+            unsupported = []
+            if n_splines != 20:
+                unsupported.append("n_splines")
+            if spline_order != 3:
+                unsupported.append("spline_order")
+            if constraints is not None:
+                unsupported.append("constraints")
+            if dtype != "numerical":
+                unsupported.append("dtype")
+            if basis != "ps":
+                unsupported.append("basis")
+            if by is not None:
+                unsupported.append("by")
+            if edge_knots is not None:
+                unsupported.append("edge_knots")
+
+            if unsupported:
+                args = ", ".join(unsupported)
+                raise ValueError(
+                    "s(..., bs='re') does not support spline-specific arguments: "
+                    f"{args}. Use f(...) for categorical random effects."
+                )
+
+            return FactorTerm(
+                feature=feature,
+                lam=lam,
+                penalties=penalties,
+                coding="one-hot",
+                verbose=verbose,
+            )
+
+        if basis != "ps" and basis != bs:
+            raise ValueError(
+                "Conflicting basis specification: set either basis or bs, "
+                "or provide matching values."
+            )
+        basis = bs
+
     return SplineTerm(
         feature=feature,
         n_splines=n_splines,

--- a/pygam/tests/test_terms.py
+++ b/pygam/tests/test_terms.py
@@ -230,6 +230,26 @@ def test_dummy_encoding(wage_X_y, wage_gam):
     assert wage_gam.terms[2].n_coefs == 5
 
 
+def test_s_bs_re_matches_factor_term(wage_X_y):
+    X, _ = wage_X_y
+
+    re_term = s(2, bs="re").compile(X)
+    factor_term = f(2).compile(X)
+
+    assert isinstance(re_term, FactorTerm)
+    assert re_term.n_coefs == factor_term.n_coefs
+    assert np.array_equal(re_term.build_columns(X).toarray(), factor_term.build_columns(X).toarray())
+    assert np.array_equal(re_term.build_penalties().toarray(), factor_term.build_penalties().toarray())
+
+
+def test_s_bs_validation_for_random_effects():
+    with pytest.raises(ValueError):
+        s(0, bs="invalid")
+
+    with pytest.raises(ValueError):
+        s(0, bs="re", n_splines=10)
+
+
 def test_build_cyclic_p_spline(hepatitis_X_y):
     """check the cyclic p spline builds
 

--- a/pygam/tests/test_terms.py
+++ b/pygam/tests/test_terms.py
@@ -238,8 +238,12 @@ def test_s_bs_re_matches_factor_term(wage_X_y):
 
     assert isinstance(re_term, FactorTerm)
     assert re_term.n_coefs == factor_term.n_coefs
-    assert np.array_equal(re_term.build_columns(X).toarray(), factor_term.build_columns(X).toarray())
-    assert np.array_equal(re_term.build_penalties().toarray(), factor_term.build_penalties().toarray())
+    assert np.array_equal(
+        re_term.build_columns(X).toarray(), factor_term.build_columns(X).toarray()
+    )
+    assert np.array_equal(
+        re_term.build_penalties().toarray(), factor_term.build_penalties().toarray()
+    )
 
 
 def test_s_bs_validation_for_random_effects():


### PR DESCRIPTION
fixes #329 
This PR adds compatibility for `mgcv-style` random effects in pyGAM by supporting `bs="re"` in s().

- `s(feature, bs="re")` now maps to FactorTerm behavior (categorical random-intercept style term with penalization).
- Added validation for bs values and clear errors for unsupported spline-only arguments when bs="re".
- Existing spline behavior is unchanged for `bs="ps"/bs="cp"` (or default basis)

Tests

- Added tests to confirm s(..., bs="re") matches f(...) in columns and penalties.
- Added tests for invalid bs values and invalid argument combinations.
- test_terms passes with the new coverage.