### PR TITLE
Add type hints for pygam directory

### DIFF
--- a/pygam/callbacks.py
+++ b/pygam/callbacks.py
@@ -1,13 +1,20 @@
 """CallBacks"""
 
+from __future__ import annotations
+
 from functools import wraps
+from typing import TYPE_CHECKING, Any, Callable
 
 import numpy as np
+import numpy.typing as npt
 
 from pygam.core import Core
 
+if TYPE_CHECKING:
+    from pygam.pygam import GAM
 
-def validate_callback_data(method):
+
+def validate_callback_data(method: Callable) -> Callable:
     """
     Wraps a callback's method to pull the desired arguments from the vars dict
     also checks to ensure the method's arguments are in the vars dict.
@@ -22,7 +29,7 @@ def validate_callback_data(method):
     """
 
     @wraps(method)
-    def method_wrapper(*args, **kwargs):
+    def method_wrapper(*args: Any, **kwargs: Any) -> Any:
         """
 
         Parameters
@@ -65,7 +72,7 @@ def validate_callback_data(method):
     return method_wrapper
 
 
-def validate_callback(callback):
+def validate_callback(callback: type[CallBack]) -> type[CallBack]:
     """
     Validates a callback's on_loop_start and on_loop_end methods.
 
@@ -77,7 +84,7 @@ def validate_callback(callback):
     -------
     validated callback
     """
-    if not (hasattr(callback, "_validated")) or callback._validated is False:
+    if not (hasattr(callback, "_validated")) or getattr(callback, "_validated") is False:
         assert hasattr(callback, "on_loop_start") or hasattr(callback, "on_loop_end"), (
             "callback must have `on_loop_start` or `on_loop_end` method"
         )
@@ -85,11 +92,11 @@ def validate_callback(callback):
             setattr(
                 callback,
                 "on_loop_start",
-                validate_callback_data(callback.on_loop_start),
+                validate_callback_data(getattr(callback, "on_loop_start")),
             )
         if hasattr(callback, "on_loop_end"):
             setattr(
-                callback, "on_loop_end", validate_callback_data(callback.on_loop_end)
+                callback, "on_loop_end", validate_callback_data(getattr(callback, "on_loop_end"))
             )
         setattr(callback, "_validated", True)
     return callback
@@ -103,7 +110,7 @@ class CallBack(Core):
     ----------
     """
 
-    def __init__(self, name=None):
+    def __init__(self, name: str | None = None) -> None:
         super(CallBack, self).__init__(name=name)
 
 
@@ -119,10 +126,10 @@ class Deviance(CallBack):
     ----------
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super(Deviance, self).__init__(name="deviance")
 
-    def on_loop_start(self, gam, y, mu):
+    def on_loop_start(self, gam: GAM, y: np.ndarray, mu: np.ndarray) -> float:
         """
         Runs the method at loop start.
 
@@ -138,7 +145,7 @@ class Deviance(CallBack):
         -------
         deviance : np.array of length n
         """
-        return gam.distribution.deviance(y=y, mu=mu, scaled=False).sum()
+        return float(gam.distribution.deviance(y=y, mu=mu, scaled=False).sum())
 
 
 @validate_callback
@@ -153,10 +160,10 @@ class Accuracy(CallBack):
     ----------
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super(Accuracy, self).__init__(name="accuracy")
 
-    def on_loop_start(self, y, mu):
+    def on_loop_start(self, y: np.ndarray, mu: np.ndarray) -> float:
         """
         Runs the method at start of each optimization loop.
 
@@ -171,7 +178,7 @@ class Accuracy(CallBack):
         -------
         accuracy : np.array of length n
         """
-        return np.mean(y == (mu > 0.5))
+        return float(np.mean(y == (mu > 0.5)))
 
 
 @validate_callback
@@ -186,10 +193,10 @@ class Diffs(CallBack):
     ----------
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super(Diffs, self).__init__(name="diffs")
 
-    def on_loop_end(self, diff):
+    def on_loop_end(self, diff: float) -> float:
         """
         Runs the method at end of each optimization loop.
 
@@ -215,22 +222,22 @@ class Coef(CallBack):
     ----------
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super(Coef, self).__init__(name="coef")
 
-    def on_loop_start(self, gam):
+    def on_loop_start(self, gam: GAM) -> np.ndarray:
         """
         Runs the method at start of each optimization loop.
 
         Parameters
         ----------
-        gam : float
+        gam : GAM instance
 
         Returns
         -------
-        coef_ : list of floats
+        coef_ : np.ndarray
         """
         return gam.coef_
 
 
-CALLBACKS = {"deviance": Deviance, "diffs": Diffs, "accuracy": Accuracy, "coef": Coef}
+CALLBACKS: dict[str, type[CallBack]] = {"deviance": Deviance, "diffs": Diffs, "accuracy": Accuracy, "coef": Coef}

--- a/pygam/callbacks.py
+++ b/pygam/callbacks.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
-import numpy.typing as npt
 
 from pygam.core import Core
 
@@ -84,7 +84,10 @@ def validate_callback(callback: type[CallBack]) -> type[CallBack]:
     -------
     validated callback
     """
-    if not (hasattr(callback, "_validated")) or getattr(callback, "_validated") is False:
+    if (
+        not (hasattr(callback, "_validated"))
+        or getattr(callback, "_validated") is False
+    ):
         assert hasattr(callback, "on_loop_start") or hasattr(callback, "on_loop_end"), (
             "callback must have `on_loop_start` or `on_loop_end` method"
         )
@@ -96,7 +99,9 @@ def validate_callback(callback: type[CallBack]) -> type[CallBack]:
             )
         if hasattr(callback, "on_loop_end"):
             setattr(
-                callback, "on_loop_end", validate_callback_data(getattr(callback, "on_loop_end"))
+                callback,
+                "on_loop_end",
+                validate_callback_data(getattr(callback, "on_loop_end")),
             )
         setattr(callback, "_validated", True)
     return callback
@@ -240,4 +245,9 @@ class Coef(CallBack):
         return gam.coef_
 
 
-CALLBACKS: dict[str, type[CallBack]] = {"deviance": Deviance, "diffs": Diffs, "accuracy": Accuracy, "coef": Coef}
+CALLBACKS: dict[str, type[CallBack]] = {
+    "deviance": Deviance,
+    "diffs": Diffs,
+    "accuracy": Accuracy,
+    "coef": Coef,
+}

--- a/pygam/core.py
+++ b/pygam/core.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
-import numpy.typing as npt
 
 from pygam.utils import flatten, round_to_n_decimal_places
 
@@ -174,7 +173,9 @@ class Core:
             ]
         )
 
-    def set_params(self, deep: bool = False, force: bool = False, **parameters: Any) -> Core:
+    def set_params(
+        self, deep: bool = False, force: bool = False, **parameters: Any
+    ) -> Core:
         """
         Sets an object's parameters.
 

--- a/pygam/core.py
+++ b/pygam/core.py
@@ -1,19 +1,24 @@
 """Core Classes"""
 
+from __future__ import annotations
+
+from typing import Any
+
 import numpy as np
+import numpy.typing as npt
 
 from pygam.utils import flatten, round_to_n_decimal_places
 
 
 def nice_repr(
-    name,
-    param_kvs,
-    line_width=30,
-    line_offset=5,
-    decimals=3,
-    args=None,
-    flatten_attrs=True,
-):
+    name: str,
+    param_kvs: dict[str, Any],
+    line_width: int = 30,
+    line_offset: int = 5,
+    decimals: int = 3,
+    args: list[Any] | None = None,
+    flatten_attrs: bool = True,
+) -> str:
     """
     Tool to do a nice repr of a class.
 
@@ -108,24 +113,29 @@ class Core:
     self
     """
 
-    def __init__(self, name=None, line_width=70, line_offset=3):
+    def __init__(
+        self,
+        name: str | None = None,
+        line_width: int = 70,
+        line_offset: int = 3,
+    ) -> None:
         self._name = name
         self._line_width = line_width
         self._line_offset = line_offset
 
         if not hasattr(self, "_exclude"):
-            self._exclude = []
+            self._exclude: list[str] = []
 
         if not hasattr(self, "_include"):
-            self._include = []
+            self._include: list[str] = []
 
-    def __str__(self):
+    def __str__(self) -> str:
         """__str__ method."""
         if self._name is None:
             return self.__repr__()
         return self._name
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """__repr__ method."""
         name = self.__class__.__name__
         return nice_repr(
@@ -137,7 +147,7 @@ class Core:
             args=None,
         )
 
-    def get_params(self, deep=False):
+    def get_params(self, deep: bool = False) -> dict[str, Any]:
         """
         Returns a dict of all of the object's user-facing parameters.
 
@@ -164,7 +174,7 @@ class Core:
             ]
         )
 
-    def set_params(self, deep=False, force=False, **parameters):
+    def set_params(self, deep: bool = False, force: bool = False, **parameters: Any) -> Core:
         """
         Sets an object's parameters.
 

--- a/pygam/distributions.py
+++ b/pygam/distributions.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
+from collections.abc import Callable
 from functools import wraps
-from typing import Any, Callable
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
@@ -16,7 +17,13 @@ from pygam.utils import ylogydu
 
 def multiply_weights(deviance: Callable) -> Callable:
     @wraps(deviance)
-    def multiplied(self: Any, y: npt.ArrayLike, mu: npt.ArrayLike, weights: npt.ArrayLike | None = None, **kwargs: Any) -> np.ndarray:
+    def multiplied(
+        self: Any,
+        y: npt.ArrayLike,
+        mu: npt.ArrayLike,
+        weights: npt.ArrayLike | None = None,
+        **kwargs: Any,
+    ) -> np.ndarray:
         if weights is None:
             weights = np.ones_like(mu)
         return deviance(self, y, mu, **kwargs) * weights
@@ -26,7 +33,12 @@ def multiply_weights(deviance: Callable) -> Callable:
 
 def divide_weights(V: Callable) -> Callable:
     @wraps(V)
-    def divided(self: Any, mu: npt.ArrayLike, weights: npt.ArrayLike | None = None, **kwargs: Any) -> np.ndarray:
+    def divided(
+        self: Any,
+        mu: npt.ArrayLike,
+        weights: npt.ArrayLike | None = None,
+        **kwargs: Any,
+    ) -> np.ndarray:
         if weights is None:
             weights = np.ones_like(mu)
         return V(self, mu, **kwargs) / weights
@@ -54,7 +66,9 @@ class Distribution(Core):
         if not self._known_scale:
             self._exclude += ["scale"]
 
-    def phi(self, y: npt.ArrayLike, mu: npt.ArrayLike, edof: float, weights: npt.ArrayLike) -> float:
+    def phi(
+        self, y: npt.ArrayLike, mu: npt.ArrayLike, edof: float, weights: npt.ArrayLike
+    ) -> float:
         """
         Related to GLM scale parameter.
         for Binomial and Poisson families this is unity
@@ -111,7 +125,9 @@ class NormalDist(Distribution):
     def __init__(self, scale: float | None = None) -> None:
         super(NormalDist, self).__init__(name="normal", scale=scale)
 
-    def log_pdf(self, y: npt.ArrayLike, mu: npt.ArrayLike, weights: npt.ArrayLike | None = None) -> np.ndarray:
+    def log_pdf(
+        self, y: npt.ArrayLike, mu: npt.ArrayLike, weights: npt.ArrayLike | None = None
+    ) -> np.ndarray:
         """
         Computes the log of the pdf or pmf of the values under the current distribution.
 
@@ -164,7 +180,9 @@ class NormalDist(Distribution):
         return np.ones_like(mu)
 
     @multiply_weights
-    def deviance(self, y: npt.ArrayLike, mu: npt.ArrayLike, scaled: bool = True) -> np.ndarray:
+    def deviance(
+        self, y: npt.ArrayLike, mu: npt.ArrayLike, scaled: bool = True
+    ) -> np.ndarray:
         """
         Model deviance.
 
@@ -226,7 +244,9 @@ class BinomialDist(Distribution):
         super(BinomialDist, self).__init__(name="binomial", scale=1.0)
         self._exclude.append("scale")
 
-    def log_pdf(self, y: npt.ArrayLike, mu: npt.ArrayLike, weights: npt.ArrayLike | None = None) -> np.ndarray:
+    def log_pdf(
+        self, y: npt.ArrayLike, mu: npt.ArrayLike, weights: npt.ArrayLike | None = None
+    ) -> np.ndarray:
         """
         Computes the log of the pdf or pmf of the values under the current distribution.
 
@@ -269,7 +289,9 @@ class BinomialDist(Distribution):
         return mu * (1 - mu / self.levels)
 
     @multiply_weights
-    def deviance(self, y: npt.ArrayLike, mu: npt.ArrayLike, scaled: bool = True) -> np.ndarray:
+    def deviance(
+        self, y: npt.ArrayLike, mu: npt.ArrayLike, scaled: bool = True
+    ) -> np.ndarray:
         """
         Model deviance.
 
@@ -324,7 +346,9 @@ class PoissonDist(Distribution):
         super(PoissonDist, self).__init__(name="poisson", scale=1.0)
         self._exclude.append("scale")
 
-    def log_pdf(self, y: npt.ArrayLike, mu: npt.ArrayLike, weights: npt.ArrayLike | None = None) -> np.ndarray:
+    def log_pdf(
+        self, y: npt.ArrayLike, mu: npt.ArrayLike, weights: npt.ArrayLike | None = None
+    ) -> np.ndarray:
         """
         Computes the log of the pdf or pmf of the values under the current distribution.
 
@@ -374,7 +398,9 @@ class PoissonDist(Distribution):
         return mu
 
     @multiply_weights
-    def deviance(self, y: npt.ArrayLike, mu: npt.ArrayLike, scaled: bool = True) -> np.ndarray:
+    def deviance(
+        self, y: npt.ArrayLike, mu: npt.ArrayLike, scaled: bool = True
+    ) -> np.ndarray:
         """
         Model deviance.
 
@@ -429,7 +455,9 @@ class GammaDist(Distribution):
     def __init__(self, scale: float | None = None) -> None:
         super(GammaDist, self).__init__(name="gamma", scale=scale)
 
-    def log_pdf(self, y: npt.ArrayLike, mu: npt.ArrayLike, weights: npt.ArrayLike | None = None) -> np.ndarray:
+    def log_pdf(
+        self, y: npt.ArrayLike, mu: npt.ArrayLike, weights: npt.ArrayLike | None = None
+    ) -> np.ndarray:
         """
         Computes the log of the pdf or pmf of the values under the current distribution.
 
@@ -471,7 +499,9 @@ class GammaDist(Distribution):
         return mu**2
 
     @multiply_weights
-    def deviance(self, y: npt.ArrayLike, mu: npt.ArrayLike, scaled: bool = True) -> np.ndarray:
+    def deviance(
+        self, y: npt.ArrayLike, mu: npt.ArrayLike, scaled: bool = True
+    ) -> np.ndarray:
         """
         Model deviance.
 
@@ -532,7 +562,9 @@ class InvGaussDist(Distribution):
     def __init__(self, scale: float | None = None) -> None:
         super(InvGaussDist, self).__init__(name="inv_gauss", scale=scale)
 
-    def log_pdf(self, y: npt.ArrayLike, mu: npt.ArrayLike, weights: npt.ArrayLike | None = None) -> np.ndarray:
+    def log_pdf(
+        self, y: npt.ArrayLike, mu: npt.ArrayLike, weights: npt.ArrayLike | None = None
+    ) -> np.ndarray:
         """
         Computes the log of the pdf or pmf of the values under the current distribution.
 
@@ -574,7 +606,9 @@ class InvGaussDist(Distribution):
         return mu**3
 
     @multiply_weights
-    def deviance(self, y: npt.ArrayLike, mu: npt.ArrayLike, scaled: bool = True) -> np.ndarray:
+    def deviance(
+        self, y: npt.ArrayLike, mu: npt.ArrayLike, scaled: bool = True
+    ) -> np.ndarray:
         """
         Model deviance.
 

--- a/pygam/links.py
+++ b/pygam/links.py
@@ -1,5 +1,7 @@
 """Link Functions"""
+
 from __future__ import annotations
+
 import numpy as np
 import numpy.typing as npt
 
@@ -31,7 +33,7 @@ class IdentityLink(Link):
     def __init__(self) -> None:
         super(IdentityLink, self).__init__(name="identity")
 
-    def link(self, mu: npt.ArrayLike, dist: Distribution) -> np.ndarray:
+    def link(self, mu: npt.ArrayLike, dist: Distribution) -> npt.ArrayLike:
         """
         Glm link function
         this is useful for going from mu to the linear prediction.
@@ -47,7 +49,7 @@ class IdentityLink(Link):
         """
         return mu
 
-    def mu(self, lp: npt.ArrayLike, dist: Distribution) -> np.ndarray:
+    def mu(self, lp: npt.ArrayLike, dist: Distribution) -> npt.ArrayLike:
         """
         Glm mean function, ie inverse of link function
         this is useful for going from the linear prediction to mu.
@@ -63,7 +65,7 @@ class IdentityLink(Link):
         """
         return lp
 
-    def gradient(self, mu: npt.ArrayLike, dist: Distribution) -> np.ndarray:
+    def gradient(self, mu: npt.ArrayLike, dist: Distribution) -> npt.ArrayLike:
         """
         Derivative of the link function wrt mu.
 
@@ -90,7 +92,7 @@ class LogitLink(Link):
     def __init__(self) -> None:
         super(LogitLink, self).__init__(name="logit")
 
-    def link(self, mu: npt.ArrayLike, dist: Distribution) -> np.ndarray:
+    def link(self, mu: npt.ArrayLike, dist: Distribution) -> npt.ArrayLike:
         """
         Glm link function
         this is useful for going from mu to the linear prediction.
@@ -106,7 +108,7 @@ class LogitLink(Link):
         """
         return np.log(mu) - np.log(dist.levels - mu)
 
-    def mu(self, lp: npt.ArrayLike, dist: Distribution) -> np.ndarray:
+    def mu(self, lp: npt.ArrayLike, dist: Distribution) -> npt.ArrayLike:
         """
         Glm mean function, ie inverse of link function
         this is useful for going from the linear prediction to mu.
@@ -123,7 +125,7 @@ class LogitLink(Link):
         elp = np.exp(lp)
         return dist.levels * elp / (elp + 1)
 
-    def gradient(self, mu: npt.ArrayLike, dist: Distribution) -> np.ndarray:
+    def gradient(self, mu: npt.ArrayLike, dist: Distribution) -> npt.ArrayLike:
         """
         Derivative of the link function wrt mu.
 
@@ -150,7 +152,7 @@ class LogLink(Link):
     def __init__(self) -> None:
         super(LogLink, self).__init__(name="log")
 
-    def link(self, mu: npt.ArrayLike, dist: Distribution) -> np.ndarray:
+    def link(self, mu: npt.ArrayLike, dist: Distribution) -> npt.ArrayLike:
         """
         Glm link function
         this is useful for going from mu to the linear prediction.
@@ -166,7 +168,7 @@ class LogLink(Link):
         """
         return np.log(mu)
 
-    def mu(self, lp: npt.ArrayLike, dist: Distribution) -> np.ndarray:
+    def mu(self, lp: npt.ArrayLike, dist: Distribution) -> npt.ArrayLike:
         """
         Glm mean function, ie inverse of link function
         this is useful for going from the linear prediction to mu.
@@ -182,7 +184,7 @@ class LogLink(Link):
         """
         return np.exp(lp)
 
-    def gradient(self, mu: npt.ArrayLike, dist: Distribution) -> np.ndarray:
+    def gradient(self, mu: npt.ArrayLike, dist: Distribution) -> npt.ArrayLike:
         """
         Derivative of the link function wrt mu.
 
@@ -209,7 +211,7 @@ class InverseLink(Link):
     def __init__(self) -> None:
         super(InverseLink, self).__init__(name="inverse")
 
-    def link(self, mu: npt.ArrayLike, dist: Distribution) -> np.ndarray:
+    def link(self, mu: npt.ArrayLike, dist: Distribution) -> npt.ArrayLike:
         """
         Glm link function
         this is useful for going from mu to the linear prediction.
@@ -225,7 +227,7 @@ class InverseLink(Link):
         """
         return mu**-1.0
 
-    def mu(self, lp: npt.ArrayLike, dist: Distribution) -> np.ndarray:
+    def mu(self, lp: npt.ArrayLike, dist: Distribution) -> npt.ArrayLike:
         """
         Glm mean function, ie inverse of link function
         this is useful for going from the linear prediction to mu.
@@ -241,7 +243,7 @@ class InverseLink(Link):
         """
         return lp**-1.0
 
-    def gradient(self, mu: npt.ArrayLike, dist: Distribution) -> np.ndarray:
+    def gradient(self, mu: npt.ArrayLike, dist: Distribution) -> npt.ArrayLike:
         """
         Derivative of the link function wrt mu.
 
@@ -268,7 +270,7 @@ class InvSquaredLink(Link):
     def __init__(self) -> None:
         super(InvSquaredLink, self).__init__(name="inv_squared")
 
-    def link(self, mu: npt.ArrayLike, dist: Distribution) -> np.ndarray:
+    def link(self, mu: npt.ArrayLike, dist: Distribution) -> npt.ArrayLike:
         """
         Glm link function
         this is useful for going from mu to the linear prediction.
@@ -284,7 +286,7 @@ class InvSquaredLink(Link):
         """
         return mu**-2.0
 
-    def mu(self, lp: npt.ArrayLike, dist: Distribution) -> np.ndarray:
+    def mu(self, lp: npt.ArrayLike, dist: Distribution) -> npt.ArrayLike:
         """
         Glm mean function, ie inverse of link function
         this is useful for going from the linear prediction to mu.
@@ -300,7 +302,7 @@ class InvSquaredLink(Link):
         """
         return lp**-0.5
 
-    def gradient(self, mu: npt.ArrayLike, dist: Distribution) -> np.ndarray:
+    def gradient(self, mu: npt.ArrayLike, dist: Distribution) -> npt.ArrayLike:
         """
         Derivative of the link function wrt mu.
 

--- a/pygam/links.py
+++ b/pygam/links.py
@@ -1,8 +1,10 @@
 """Link Functions"""
-
+from __future__ import annotations
 import numpy as np
+import numpy.typing as npt
 
 from pygam.core import Core
+from pygam.distributions import Distribution
 
 
 class Link(Core):
@@ -14,7 +16,7 @@ class Link(Core):
     name : str, default: None
     """
 
-    def __init__(self, name=None):
+    def __init__(self, name: str | None = None) -> None:
         super(Link, self).__init__(name=name)
 
 
@@ -26,10 +28,10 @@ class IdentityLink(Link):
     ----------
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super(IdentityLink, self).__init__(name="identity")
 
-    def link(self, mu, dist):
+    def link(self, mu: npt.ArrayLike, dist: Distribution) -> np.ndarray:
         """
         Glm link function
         this is useful for going from mu to the linear prediction.
@@ -45,7 +47,7 @@ class IdentityLink(Link):
         """
         return mu
 
-    def mu(self, lp, dist):
+    def mu(self, lp: npt.ArrayLike, dist: Distribution) -> np.ndarray:
         """
         Glm mean function, ie inverse of link function
         this is useful for going from the linear prediction to mu.
@@ -61,7 +63,7 @@ class IdentityLink(Link):
         """
         return lp
 
-    def gradient(self, mu, dist):
+    def gradient(self, mu: npt.ArrayLike, dist: Distribution) -> np.ndarray:
         """
         Derivative of the link function wrt mu.
 
@@ -85,10 +87,10 @@ class LogitLink(Link):
     ----------
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super(LogitLink, self).__init__(name="logit")
 
-    def link(self, mu, dist):
+    def link(self, mu: npt.ArrayLike, dist: Distribution) -> np.ndarray:
         """
         Glm link function
         this is useful for going from mu to the linear prediction.
@@ -104,7 +106,7 @@ class LogitLink(Link):
         """
         return np.log(mu) - np.log(dist.levels - mu)
 
-    def mu(self, lp, dist):
+    def mu(self, lp: npt.ArrayLike, dist: Distribution) -> np.ndarray:
         """
         Glm mean function, ie inverse of link function
         this is useful for going from the linear prediction to mu.
@@ -121,7 +123,7 @@ class LogitLink(Link):
         elp = np.exp(lp)
         return dist.levels * elp / (elp + 1)
 
-    def gradient(self, mu, dist):
+    def gradient(self, mu: npt.ArrayLike, dist: Distribution) -> np.ndarray:
         """
         Derivative of the link function wrt mu.
 
@@ -145,10 +147,10 @@ class LogLink(Link):
     ----------
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super(LogLink, self).__init__(name="log")
 
-    def link(self, mu, dist):
+    def link(self, mu: npt.ArrayLike, dist: Distribution) -> np.ndarray:
         """
         Glm link function
         this is useful for going from mu to the linear prediction.
@@ -164,7 +166,7 @@ class LogLink(Link):
         """
         return np.log(mu)
 
-    def mu(self, lp, dist):
+    def mu(self, lp: npt.ArrayLike, dist: Distribution) -> np.ndarray:
         """
         Glm mean function, ie inverse of link function
         this is useful for going from the linear prediction to mu.
@@ -180,7 +182,7 @@ class LogLink(Link):
         """
         return np.exp(lp)
 
-    def gradient(self, mu, dist):
+    def gradient(self, mu: npt.ArrayLike, dist: Distribution) -> np.ndarray:
         """
         Derivative of the link function wrt mu.
 
@@ -204,10 +206,10 @@ class InverseLink(Link):
     ----------
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super(InverseLink, self).__init__(name="inverse")
 
-    def link(self, mu, dist):
+    def link(self, mu: npt.ArrayLike, dist: Distribution) -> np.ndarray:
         """
         Glm link function
         this is useful for going from mu to the linear prediction.
@@ -223,7 +225,7 @@ class InverseLink(Link):
         """
         return mu**-1.0
 
-    def mu(self, lp, dist):
+    def mu(self, lp: npt.ArrayLike, dist: Distribution) -> np.ndarray:
         """
         Glm mean function, ie inverse of link function
         this is useful for going from the linear prediction to mu.
@@ -239,7 +241,7 @@ class InverseLink(Link):
         """
         return lp**-1.0
 
-    def gradient(self, mu, dist):
+    def gradient(self, mu: npt.ArrayLike, dist: Distribution) -> np.ndarray:
         """
         Derivative of the link function wrt mu.
 
@@ -263,10 +265,10 @@ class InvSquaredLink(Link):
     ----------
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super(InvSquaredLink, self).__init__(name="inv_squared")
 
-    def link(self, mu, dist):
+    def link(self, mu: npt.ArrayLike, dist: Distribution) -> np.ndarray:
         """
         Glm link function
         this is useful for going from mu to the linear prediction.
@@ -282,7 +284,7 @@ class InvSquaredLink(Link):
         """
         return mu**-2.0
 
-    def mu(self, lp, dist):
+    def mu(self, lp: npt.ArrayLike, dist: Distribution) -> np.ndarray:
         """
         Glm mean function, ie inverse of link function
         this is useful for going from the linear prediction to mu.
@@ -298,7 +300,7 @@ class InvSquaredLink(Link):
         """
         return lp**-0.5
 
-    def gradient(self, mu, dist):
+    def gradient(self, mu: npt.ArrayLike, dist: Distribution) -> np.ndarray:
         """
         Derivative of the link function wrt mu.
 
@@ -314,7 +316,7 @@ class InvSquaredLink(Link):
         return -2 * mu**-3.0
 
 
-LINKS = {
+LINKS: dict[str, type[Link]] = {
     "identity": IdentityLink,
     "log": LogLink,
     "logit": LogitLink,

--- a/pygam/penalties.py
+++ b/pygam/penalties.py
@@ -1,12 +1,14 @@
 """Penalty Matrix Generators"""
-
+from __future__ import annotations
 import warnings
+from typing import Any, Callable
 
 import numpy as np
+import numpy.typing as npt
 import scipy as sp
 
 
-def derivative(n, coef, derivative=2, periodic=False):
+def derivative(n: int, coef: Any, derivative: int = 2, periodic: bool = False) -> sp.sparse.csc_array:
     """
     Builds a penalty matrix for P-Splines with continuous features.
     Penalizes the squared differences between basis coefficients.
@@ -49,11 +51,11 @@ def derivative(n, coef, derivative=2, periodic=False):
     return D.dot(D.T).tocsc()
 
 
-def periodic(n, coef, derivative=2, _penalty=derivative):
+def periodic(n: int, coef: Any, derivative: int = 2, _penalty: Callable = derivative) -> sp.sparse.csc_array:
     return _penalty(n, coef, derivative=derivative, periodic=True)
 
 
-def l2(n, coef):
+def l2(n: int, coef: Any) -> sp.sparse.csc_array:
     """
     Builds a penalty matrix for P-Splines with categorical features.
     Penalizes the squared value of each basis coefficient.
@@ -73,7 +75,7 @@ def l2(n, coef):
     return sp.sparse.eye(n).tocsc()
 
 
-def monotonicity_(n, coef, increasing=True):
+def monotonicity_(n: int, coef: np.ndarray, increasing: bool = True) -> sp.sparse.csc_array:
     """
     Builds a penalty matrix for P-Splines with continuous features.
     Penalizes violation of monotonicity in the feature function.
@@ -113,7 +115,7 @@ def monotonicity_(n, coef, increasing=True):
     return D.dot(D.T).tocsc()
 
 
-def monotonic_inc(n, coef):
+def monotonic_inc(n: int, coef: np.ndarray) -> sp.sparse.csc_array:
     """
     Builds a penalty matrix for P-Splines with continuous features.
     Penalizes violation of a monotonic increasing feature function.
@@ -131,7 +133,7 @@ def monotonic_inc(n, coef):
     return monotonicity_(n, coef, increasing=True)
 
 
-def monotonic_dec(n, coef):
+def monotonic_dec(n: int, coef: np.ndarray) -> sp.sparse.csc_array:
     """
     Builds a penalty matrix for P-Splines with continuous features.
     Penalizes violation of a monotonic decreasing feature function.
@@ -150,7 +152,7 @@ def monotonic_dec(n, coef):
     return monotonicity_(n, coef, increasing=False)
 
 
-def convexity_(n, coef, convex=True):
+def convexity_(n: int, coef: np.ndarray, convex: bool = True) -> sp.sparse.csc_array:
     """
     Builds a penalty matrix for P-Splines with continuous features.
     Penalizes violation of convexity in the feature function.
@@ -188,7 +190,7 @@ def convexity_(n, coef, convex=True):
     return D.dot(D.T).tocsc()
 
 
-def convex(n, coef):
+def convex(n: int, coef: np.ndarray) -> sp.sparse.csc_array:
     """
     Builds a penalty matrix for P-Splines with continuous features.
     Penalizes violation of a convex feature function.
@@ -207,7 +209,7 @@ def convex(n, coef):
     return convexity_(n, coef, convex=True)
 
 
-def concave(n, coef):
+def concave(n: int, coef: np.ndarray) -> sp.sparse.csc_array:
     """
     Builds a penalty matrix for P-Splines with continuous features.
     Penalizes violation of a concave feature function.
@@ -258,7 +260,7 @@ def concave(n, coef):
 #     return P.tocsc()
 
 
-def none(n, coef):
+def none(n: int, coef: Any) -> sp.sparse.csc_array:
     """
     Build a matrix of zeros for features that should go unpenalized.
 
@@ -276,7 +278,7 @@ def none(n, coef):
     return sp.sparse.csc_array((n, n))
 
 
-def wrap_penalty(p, fit_linear, linear_penalty=0.0):
+def wrap_penalty(p: Callable, fit_linear: bool, linear_penalty: float = 0.0) -> Callable:
     """
     Tool to account for unity penalty on the linear term of any feature.
 
@@ -298,7 +300,7 @@ def wrap_penalty(p, fit_linear, linear_penalty=0.0):
       modified penalty-matrix-generating function
     """
 
-    def wrapped_p(n, *args):
+    def wrapped_p(n: int, *args: Any) -> sp.sparse.csc_array:
         if fit_linear:
             if n == 1:
                 return sp.sparse.block_diag([linear_penalty], format="csc")
@@ -309,7 +311,7 @@ def wrap_penalty(p, fit_linear, linear_penalty=0.0):
     return wrapped_p
 
 
-def sparse_diff(array, n=1, axis=-1):
+def sparse_diff(array: sp.sparse.sparray, n: int = 1, axis: int = -1) -> sp.sparse.sparray:
     """
     A ported sparse version of np.diff.
     Uses recursion to compute higher order differences.
@@ -348,7 +350,7 @@ def sparse_diff(array, n=1, axis=-1):
     return A[slice1] - A[slice2]
 
 
-PENALTIES = {
+PENALTIES: dict[str, Any] = {
     "auto": "auto",
     "derivative": derivative,
     "l2": l2,
@@ -356,7 +358,7 @@ PENALTIES = {
     "periodic": periodic,
 }
 
-CONSTRAINTS = {
+CONSTRAINTS: dict[str, Any] = {
     "convex": convex,
     "concave": concave,
     "monotonic_inc": monotonic_inc,

--- a/pygam/penalties.py
+++ b/pygam/penalties.py
@@ -1,14 +1,18 @@
 """Penalty Matrix Generators"""
+
 from __future__ import annotations
+
 import warnings
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import numpy as np
-import numpy.typing as npt
 import scipy as sp
 
 
-def derivative(n: int, coef: Any, derivative: int = 2, periodic: bool = False) -> sp.sparse.csc_array:
+def derivative(
+    n: int, coef: Any, derivative: int = 2, periodic: bool = False
+) -> sp.sparse.spmatrix | sp.sparse.sparray:
     """
     Builds a penalty matrix for P-Splines with continuous features.
     Penalizes the squared differences between basis coefficients.
@@ -51,11 +55,13 @@ def derivative(n: int, coef: Any, derivative: int = 2, periodic: bool = False) -
     return D.dot(D.T).tocsc()
 
 
-def periodic(n: int, coef: Any, derivative: int = 2, _penalty: Callable = derivative) -> sp.sparse.csc_array:
+def periodic(
+    n: int, coef: Any, derivative: int = 2, _penalty: Callable = derivative
+) -> sp.sparse.spmatrix | sp.sparse.sparray:
     return _penalty(n, coef, derivative=derivative, periodic=True)
 
 
-def l2(n: int, coef: Any) -> sp.sparse.csc_array:
+def l2(n: int, coef: Any) -> sp.sparse.spmatrix | sp.sparse.sparray:
     """
     Builds a penalty matrix for P-Splines with categorical features.
     Penalizes the squared value of each basis coefficient.
@@ -75,7 +81,9 @@ def l2(n: int, coef: Any) -> sp.sparse.csc_array:
     return sp.sparse.eye(n).tocsc()
 
 
-def monotonicity_(n: int, coef: np.ndarray, increasing: bool = True) -> sp.sparse.csc_array:
+def monotonicity_(
+    n: int, coef: np.ndarray, increasing: bool = True
+) -> sp.sparse.spmatrix | sp.sparse.sparray:
     """
     Builds a penalty matrix for P-Splines with continuous features.
     Penalizes violation of monotonicity in the feature function.
@@ -115,7 +123,7 @@ def monotonicity_(n: int, coef: np.ndarray, increasing: bool = True) -> sp.spars
     return D.dot(D.T).tocsc()
 
 
-def monotonic_inc(n: int, coef: np.ndarray) -> sp.sparse.csc_array:
+def monotonic_inc(n: int, coef: np.ndarray) -> sp.sparse.spmatrix | sp.sparse.sparray:
     """
     Builds a penalty matrix for P-Splines with continuous features.
     Penalizes violation of a monotonic increasing feature function.
@@ -133,7 +141,7 @@ def monotonic_inc(n: int, coef: np.ndarray) -> sp.sparse.csc_array:
     return monotonicity_(n, coef, increasing=True)
 
 
-def monotonic_dec(n: int, coef: np.ndarray) -> sp.sparse.csc_array:
+def monotonic_dec(n: int, coef: np.ndarray) -> sp.sparse.spmatrix | sp.sparse.sparray:
     """
     Builds a penalty matrix for P-Splines with continuous features.
     Penalizes violation of a monotonic decreasing feature function.
@@ -152,7 +160,7 @@ def monotonic_dec(n: int, coef: np.ndarray) -> sp.sparse.csc_array:
     return monotonicity_(n, coef, increasing=False)
 
 
-def convexity_(n: int, coef: np.ndarray, convex: bool = True) -> sp.sparse.csc_array:
+def convexity_(n: int, coef: np.ndarray, convex: bool = True) -> sp.sparse.spmatrix | sp.sparse.sparray:
     """
     Builds a penalty matrix for P-Splines with continuous features.
     Penalizes violation of convexity in the feature function.
@@ -190,7 +198,7 @@ def convexity_(n: int, coef: np.ndarray, convex: bool = True) -> sp.sparse.csc_a
     return D.dot(D.T).tocsc()
 
 
-def convex(n: int, coef: np.ndarray) -> sp.sparse.csc_array:
+def convex(n: int, coef: np.ndarray) -> sp.sparse.spmatrix | sp.sparse.sparray:
     """
     Builds a penalty matrix for P-Splines with continuous features.
     Penalizes violation of a convex feature function.
@@ -209,7 +217,7 @@ def convex(n: int, coef: np.ndarray) -> sp.sparse.csc_array:
     return convexity_(n, coef, convex=True)
 
 
-def concave(n: int, coef: np.ndarray) -> sp.sparse.csc_array:
+def concave(n: int, coef: np.ndarray) -> sp.sparse.spmatrix | sp.sparse.sparray:
     """
     Builds a penalty matrix for P-Splines with continuous features.
     Penalizes violation of a concave feature function.
@@ -278,7 +286,9 @@ def none(n: int, coef: Any) -> sp.sparse.csc_array:
     return sp.sparse.csc_array((n, n))
 
 
-def wrap_penalty(p: Callable, fit_linear: bool, linear_penalty: float = 0.0) -> Callable:
+def wrap_penalty(
+    p: Callable, fit_linear: bool, linear_penalty: float = 0.0
+) -> Callable:
     """
     Tool to account for unity penalty on the linear term of any feature.
 
@@ -300,7 +310,7 @@ def wrap_penalty(p: Callable, fit_linear: bool, linear_penalty: float = 0.0) -> 
       modified penalty-matrix-generating function
     """
 
-    def wrapped_p(n: int, *args: Any) -> sp.sparse.csc_array:
+    def wrapped_p(n: int, *args: Any) -> sp.sparse.spmatrix | sp.sparse.sparray:
         if fit_linear:
             if n == 1:
                 return sp.sparse.block_diag([linear_penalty], format="csc")
@@ -311,7 +321,9 @@ def wrap_penalty(p: Callable, fit_linear: bool, linear_penalty: float = 0.0) -> 
     return wrapped_p
 
 
-def sparse_diff(array: sp.sparse.sparray, n: int = 1, axis: int = -1) -> sp.sparse.sparray:
+def sparse_diff(
+    array: sp.sparse.sparray, n: int = 1, axis: int = -1
+) -> sp.sparse.sparray:
     """
     A ported sparse version of np.diff.
     Uses recursion to compute higher order differences.

--- a/pygam/terms.py
+++ b/pygam/terms.py
@@ -149,7 +149,7 @@ class Term(Core):
             args=features,
         )
 
-    def _validate_arguments(self) -> Term:
+    def _validate_arguments(self) -> None:
         """Method to sanitize model parameters.
 
         Parameters
@@ -308,7 +308,7 @@ class Term(Core):
         """
         pass
 
-    def build_penalties(self, verbose: bool = False) -> sp.sparse.sparray | np.ndarray:
+    def build_penalties(self, verbose: bool = False) -> sp.sparse.spmatrix | sp.sparse.sparray | np.ndarray:
         """
         Builds the GAM block-diagonal penalty matrix in quadratic form
         out of penalty matrices specified for each feature.
@@ -352,7 +352,9 @@ class Term(Core):
             Ps.append(np.multiply(P, lam))
         return np.sum(Ps)
 
-    def build_constraints(self, coef: np.ndarray, constraint_lam: float, constraint_l2: float) -> sp.sparse.sparray | np.ndarray:
+    def build_constraints(
+        self, coef: np.ndarray, constraint_lam: float, constraint_l2: float
+    ) -> sp.sparse.spmatrix | sp.sparse.sparray | np.ndarray:
         """
         Builds the GAM block-diagonal constraint matrix in quadratic form
         out of constraint matrices specified for each feature.
@@ -585,7 +587,9 @@ class Intercept(Term):
         """
         return self
 
-    def build_columns(self, X: np.ndarray, verbose: bool = False) -> sp.sparse.csc_array:
+    def build_columns(
+        self, X: np.ndarray, verbose: bool = False
+    ) -> sp.sparse.csc_array:
         """Construct the model matrix columns for the term.
 
         Parameters
@@ -649,7 +653,13 @@ class LinearTerm(Term):
         contains dict with the sufficient information to duplicate the term
     """
 
-    def __init__(self, feature: int, lam: float | list[float] = 0.6, penalties: str | list[str | None] | Any = "auto", verbose: bool = False) -> None:
+    def __init__(
+        self,
+        feature: int,
+        lam: float | list[float] = 0.6,
+        penalties: str | list[str | None] | Any = "auto",
+        verbose: bool = False,
+    ) -> None:
         self._name = "linear_term"
         self._minimal_name = "l"
         super(LinearTerm, self).__init__(
@@ -694,7 +704,9 @@ class LinearTerm(Term):
         )
         return self
 
-    def build_columns(self, X: np.ndarray, verbose: bool = False) -> sp.sparse.csc_array:
+    def build_columns(
+        self, X: np.ndarray, verbose: bool = False
+    ) -> sp.sparse.csc_array:
         """Construct the model matrix columns for the term.
 
         Parameters
@@ -927,7 +939,9 @@ class SplineTerm(Term):
             )
         return self
 
-    def build_columns(self, X: np.ndarray, verbose: bool = False) -> sp.sparse.csc_array:
+    def build_columns(
+        self, X: np.ndarray, verbose: bool = False
+    ) -> sp.sparse.csc_array:
         """Construct the model matrix columns for the term.
 
         Parameters
@@ -1012,7 +1026,12 @@ class FactorTerm(SplineTerm):
     _encodings = ["one-hot", "dummy"]
 
     def __init__(
-        self, feature: int, lam: float | list[float] = 0.6, penalties: str | list[str | None] | Any = "auto", coding: str = "one-hot", verbose: bool = False
+        self,
+        feature: int,
+        lam: float | list[float] = 0.6,
+        penalties: str | list[str | None] | Any = "auto",
+        coding: str = "one-hot",
+        verbose: bool = False,
     ) -> None:
         self.coding = coding
         super(FactorTerm, self).__init__(
@@ -1078,7 +1097,9 @@ class FactorTerm(SplineTerm):
         )
         return self
 
-    def build_columns(self, X: np.ndarray, verbose: bool = False) -> sp.sparse.csc_array:
+    def build_columns(
+        self, X: np.ndarray, verbose: bool = False
+    ) -> sp.sparse.csc_array:
         """Construct the model matrix columns for the term.
 
         Parameters
@@ -1455,7 +1476,9 @@ class TensorTerm(SplineTerm, MetaTermMixin):
             )
         return self
 
-    def build_columns(self, X: np.ndarray, verbose: bool = False) -> sp.sparse.csc_array:
+    def build_columns(
+        self, X: np.ndarray, verbose: bool = False
+    ) -> sp.sparse.csc_array:
         """Construct the model matrix columns for the term.
 
         Parameters
@@ -1504,7 +1527,7 @@ class TensorTerm(SplineTerm, MetaTermMixin):
 
         return sp.sparse.csc_array(P)
 
-    def _build_marginal_penalties(self, i: int) -> sp.sparse.sparray:
+    def _build_marginal_penalties(self, i: int) -> sp.sparse.spmatrix | sp.sparse.sparray:
         for j, term in enumerate(self._terms):
             # make appropriate marginal penalty
             if j == i:
@@ -1520,7 +1543,9 @@ class TensorTerm(SplineTerm, MetaTermMixin):
 
         return P_total
 
-    def build_constraints(self, coef: np.ndarray, constraint_lam: float, constraint_l2: float) -> sp.sparse.csc_array:
+    def build_constraints(
+        self, coef: np.ndarray, constraint_lam: float, constraint_l2: float
+    ) -> sp.sparse.csc_array:
         """
         Builds the GAM block-diagonal constraint matrix in quadratic form
         out of constraint matrices specified for each feature.
@@ -1552,7 +1577,9 @@ class TensorTerm(SplineTerm, MetaTermMixin):
 
         return C.tocsc()
 
-    def _build_marginal_constraints(self, i: int, coef: np.ndarray, constraint_lam: float, constraint_l2: float) -> sp.sparse.csc_array:
+    def _build_marginal_constraints(
+        self, i: int, coef: np.ndarray, constraint_lam: float, constraint_l2: float
+    ) -> sp.sparse.csc_array:
         """Builds a constraint matrix for a marginal term in the tensor term.
 
         takes a tensor's coef vector, and slices it into pieces corresponding
@@ -1902,7 +1929,9 @@ class TermList(Core, MetaTermMixin):
         stop = start + self._terms[i].n_coefs
         return list(range(start, stop))
 
-    def build_columns(self, X: np.ndarray, term: int | list[int] = -1, verbose: bool = False) -> sp.sparse.csc_array:
+    def build_columns(
+        self, X: np.ndarray, term: int | list[int] = -1, verbose: bool = False
+    ) -> sp.sparse.csc_array:
         """Construct the model matrix columns for the term.
 
         Parameters
@@ -1950,7 +1979,9 @@ class TermList(Core, MetaTermMixin):
             P.append(term.build_penalties())
         return sp.sparse.block_diag(P).tocsc()
 
-    def build_constraints(self, coefs: np.ndarray, constraint_lam: float, constraint_l2: float) -> sp.sparse.sparray:
+    def build_constraints(
+        self, coefs: np.ndarray, constraint_lam: float, constraint_l2: float
+    ) -> sp.sparse.spmatrix | sp.sparse.sparray:
         """
         Builds the GAM block-diagonal constraint matrix in quadratic form
         out of constraint matrices specified for each feature.
@@ -1984,7 +2015,12 @@ class TermList(Core, MetaTermMixin):
 
 
 # Minimal representations
-def l(feature: int, lam: float | list[float] = 0.6, penalties: str | list[str | None] | Any = "auto", verbose: bool = False) -> LinearTerm:  # noqa: E743
+def l(
+    feature: int,
+    lam: float | list[float] = 0.6,
+    penalties: str | list[str | None] | Any = "auto",
+    verbose: bool = False,
+) -> LinearTerm:  # noqa: E743
     """
 
     See Also
@@ -2028,7 +2064,13 @@ def s(
     )
 
 
-def f(feature: int, lam: float | list[float] = 0.6, penalties: str | list[str | None] | Any = "auto", coding: str = "one-hot", verbose: bool = False) -> FactorTerm:
+def f(
+    feature: int,
+    lam: float | list[float] = 0.6,
+    penalties: str | list[str | None] | Any = "auto",
+    coding: str = "one-hot",
+    verbose: bool = False,
+) -> FactorTerm:
     """
 
     See Also

--- a/pygam/utils.py
+++ b/pygam/utils.py
@@ -1,11 +1,15 @@
 """pyGAM Utilities"""
 
+from __future__ import annotations
+
 import numbers
 import sys
 import warnings
 from copy import deepcopy
+from typing import Any
 
 import numpy as np
+import numpy.typing as npt
 import scipy as sp
 from numpy.linalg import LinAlgError
 from scipy import sparse  # noqa: F401
@@ -27,7 +31,7 @@ class OptimizationError(ValueError):
     """Exception class to raise if PIRLS optimization fails."""
 
 
-def cholesky(A, sparse=True, verbose=True):  # noqa: F811
+def cholesky(A: npt.ArrayLike, sparse: bool = True, verbose: bool = True) -> np.ndarray | sp.sparse.csc_array:  # noqa: F811
     """
     Choose the best possible cholesky factorizor.
 
@@ -91,7 +95,7 @@ def cholesky(A, sparse=True, verbose=True):  # noqa: F811
         return L
 
 
-def make_2d(array, verbose=True):
+def make_2d(array: npt.ArrayLike, verbose: bool = True) -> np.ndarray:
     """
     Tiny tool to expand 1D arrays the way i want.
 
@@ -116,14 +120,14 @@ def make_2d(array, verbose=True):
 
 
 def check_array(
-    array,
-    force_2d=False,
-    n_feats=None,
-    ndim=None,
-    min_samples=1,
-    name="Input data",
-    verbose=True,
-):
+    array: npt.ArrayLike,
+    force_2d: bool = False,
+    n_feats: int | None = None,
+    ndim: int | None = None,
+    min_samples: int = 1,
+    name: str = "Input data",
+    verbose: bool = True,
+) -> np.ndarray:
     """
     Tool to perform basic data validation.
     called by check_X and check_y.
@@ -201,7 +205,7 @@ def check_array(
     return array
 
 
-def check_y(y, link, dist, min_samples=1, verbose=True):
+def check_y(y: npt.ArrayLike, link: Any, dist: Any, min_samples: int = 1, verbose: bool = True) -> np.ndarray:
     """
     Tool to ensure that the targets:
     - are in the domain of the link function
@@ -249,14 +253,14 @@ def check_y(y, link, dist, min_samples=1, verbose=True):
 
 
 def check_X(
-    X,
-    n_feats=None,
-    min_samples=1,
-    edge_knots=None,
-    dtypes=None,
-    features=None,
-    verbose=True,
-):
+    X: npt.ArrayLike,
+    n_feats: int | None = None,
+    min_samples: int = 1,
+    edge_knots: list[np.ndarray] | None = None,
+    dtypes: list[str] | None = None,
+    features: list[int] | None = None,
+    verbose: bool = True,
+) -> np.ndarray:
     """
     Tool to ensure that X:
     - is 2 dimensional
@@ -336,7 +340,7 @@ def check_X(
     return X
 
 
-def check_X_y(X, y):
+def check_X_y(X: np.ndarray, y: np.ndarray) -> None:
     """
     Tool to ensure input and output data have the same number of samples.
 
@@ -355,7 +359,7 @@ def check_X_y(X, y):
         )
 
 
-def check_lengths(*arrays):
+def check_lengths(*arrays: npt.ArrayLike) -> None:
     """
     Tool to ensure input and output data have the same number of samples.
 
@@ -372,7 +376,7 @@ def check_lengths(*arrays):
         raise ValueError(f"Inconsistent data lengths: {lengths}")
 
 
-def check_param(param, param_name, dtype, constraint=None, iterable=True, max_depth=2):
+def check_param(param: Any, param_name: str, dtype: str, constraint: str | None = None, iterable: bool = True, max_depth: int = 2) -> Any:
     """
     Checks the dtype of a parameter,
     and whether it satisfies a numerical constraint.
@@ -441,7 +445,7 @@ def check_param(param, param_name, dtype, constraint=None, iterable=True, max_de
     return param
 
 
-def get_link_domain(link, dist):
+def get_link_domain(link: Any, dist: Any) -> list[float]:
     """
     Tool to identify the domain of a given monotonic link function.
 
@@ -459,7 +463,7 @@ def get_link_domain(link, dist):
     return [domain[0], domain[-1]]
 
 
-def load_diagonal(cov, load=None):
+def load_diagonal(cov: np.ndarray, load: float | None = None) -> np.ndarray:
     """Return the given square matrix with a small amount added to the diagonal
     to make it positive semi-definite.
     """
@@ -471,7 +475,7 @@ def load_diagonal(cov, load=None):
     return cov + np.eye(n) * load
 
 
-def round_to_n_decimal_places(array, n=3):
+def round_to_n_decimal_places(array: float | np.ndarray, n: int = 3) -> float | np.ndarray:
     """
     Tool to keep round a float to n decimal places.
 
@@ -500,7 +504,7 @@ def round_to_n_decimal_places(array, n=3):
 class TablePrinter:
     """Print a list of dicts as a table."""
 
-    def __init__(self, fmt, sep=" ", ul=None):
+    def __init__(self, fmt: list[tuple[str, str, int]], sep: str = " ", ul: str | None = None) -> None:
         """
         @param fmt: list of tuple(heading, key, width)
                         heading: str, column label
@@ -518,7 +522,7 @@ class TablePrinter:
         self.ul = {key: str(ul) * width for heading, key, width in fmt} if ul else None
         self.width = {key: width for heading, key, width in fmt}
 
-    def row(self, data):
+    def row(self, data: dict[str, Any]) -> str:
         if sys.version_info < (3,):
             return self.fmt.format(
                 **{k: str(data.get(k, ""))[:w] for k, w in self.width.iteritems()}
@@ -528,7 +532,7 @@ class TablePrinter:
                 **{k: str(data.get(k, ""))[:w] for k, w in self.width.items()}
             )
 
-    def __call__(self, dataList):
+    def __call__(self, dataList: list[dict[str, Any]]) -> str:
         _r = self.row
         res = [_r(data) for data in dataList]
         res.insert(0, _r(self.head))
@@ -537,7 +541,7 @@ class TablePrinter:
         return "\n".join(res)
 
 
-def space_row(left, right, filler=" ", total_width=-1):
+def space_row(left: Any, right: Any, filler: str = " ", total_width: int = -1) -> str:
     """Space the data in a row with optional filling.
 
     Arguments
@@ -566,7 +570,7 @@ def space_row(left, right, filler=" ", total_width=-1):
     return left + filler * spacing + right
 
 
-def sig_code(p_value):
+def sig_code(p_value: float) -> str:
     """Create a significance code in the style of R's lm.
 
     Arguments
@@ -589,7 +593,7 @@ def sig_code(p_value):
     return " "
 
 
-def gen_edge_knots(data, dtype, verbose=True):
+def gen_edge_knots(data: npt.ArrayLike, dtype: str, verbose: bool = True) -> np.ndarray:
     """
     Generate uniform knots from data including the edges of the data.
 
@@ -622,14 +626,14 @@ def gen_edge_knots(data, dtype, verbose=True):
 
 
 def b_spline_basis(
-    x,
-    edge_knots,
-    n_splines=20,
-    spline_order=3,
-    sparse=True,  # noqa: F811
-    periodic=True,
-    verbose=True,
-):
+    x: npt.ArrayLike,
+    edge_knots: npt.ArrayLike,
+    n_splines: int = 20,
+    spline_order: int = 3,
+    sparse: bool = True,  # noqa: F811
+    periodic: bool = True,
+    verbose: bool = True,
+) -> sp.sparse.csc_array | np.ndarray:
     """
     Tool to generate b-spline basis using vectorized De Boor recursion
     the basis functions extrapolate linearly past the end-knots.
@@ -770,7 +774,7 @@ def b_spline_basis(
     return bases
 
 
-def ylogydu(y, u):
+def ylogydu(y: np.ndarray, u: np.ndarray) -> np.ndarray:
     """
     Tool to give desired output for the limit as y -> 0, which is 0.
 
@@ -789,7 +793,7 @@ def ylogydu(y, u):
     return out
 
 
-def combine(*args):
+def combine(*args: list[Any]) -> list[list[Any]]:
     """
     Tool to perform tree search via recursion
     useful for developing the grid in a grid search.
@@ -816,7 +820,7 @@ def combine(*args):
         return [[arg] for arg in args[0]]
 
 
-def isiterable(obj, reject_string=True):
+def isiterable(obj: Any, reject_string: bool = True) -> bool:
     """Convenience tool to detect if something is iterable.
     in python3, strings count as iterables to we have the option to exclude them.
 
@@ -837,7 +841,7 @@ def isiterable(obj, reject_string=True):
     return iterable
 
 
-def check_iterable_depth(obj, max_depth=100):
+def check_iterable_depth(obj: Any, max_depth: int = 100) -> int:
     """Find the maximum depth of nesting of the iterable.
 
     Parameters
@@ -865,7 +869,7 @@ def check_iterable_depth(obj, max_depth=100):
     return depth
 
 
-def flatten(iterable):
+def flatten(iterable: Any) -> Any:
     """Convenience tool to flatten any nested iterable.
 
     example:
@@ -896,7 +900,7 @@ def flatten(iterable):
         return iterable
 
 
-def tensor_product(a, b, reshape=True):
+def tensor_product(a: np.ndarray | sp.sparse.sparray, b: np.ndarray | sp.sparse.sparray, reshape: bool = True) -> np.ndarray:
     """
     Compute the tensor protuct of two matrices a and b.
 

--- a/pygam/utils.py
+++ b/pygam/utils.py
@@ -31,7 +31,9 @@ class OptimizationError(ValueError):
     """Exception class to raise if PIRLS optimization fails."""
 
 
-def cholesky(A: npt.ArrayLike, sparse: bool = True, verbose: bool = True) -> np.ndarray | sp.sparse.csc_array:  # noqa: F811
+def cholesky(
+    A: npt.ArrayLike, sparse: bool = True, verbose: bool = True
+) -> np.ndarray | sp.sparse.csc_array:  # noqa: F811
     """
     Choose the best possible cholesky factorizor.
 
@@ -205,7 +207,9 @@ def check_array(
     return array
 
 
-def check_y(y: npt.ArrayLike, link: Any, dist: Any, min_samples: int = 1, verbose: bool = True) -> np.ndarray:
+def check_y(
+    y: npt.ArrayLike, link: Any, dist: Any, min_samples: int = 1, verbose: bool = True
+) -> np.ndarray:
     """
     Tool to ensure that the targets:
     - are in the domain of the link function
@@ -376,7 +380,14 @@ def check_lengths(*arrays: npt.ArrayLike) -> None:
         raise ValueError(f"Inconsistent data lengths: {lengths}")
 
 
-def check_param(param: Any, param_name: str, dtype: str, constraint: str | None = None, iterable: bool = True, max_depth: int = 2) -> Any:
+def check_param(
+    param: Any,
+    param_name: str,
+    dtype: str,
+    constraint: str | None = None,
+    iterable: bool = True,
+    max_depth: int = 2,
+) -> Any:
     """
     Checks the dtype of a parameter,
     and whether it satisfies a numerical constraint.
@@ -475,7 +486,9 @@ def load_diagonal(cov: np.ndarray, load: float | None = None) -> np.ndarray:
     return cov + np.eye(n) * load
 
 
-def round_to_n_decimal_places(array: float | np.ndarray, n: int = 3) -> float | np.ndarray:
+def round_to_n_decimal_places(
+    array: float | np.ndarray, n: int = 3
+) -> float | np.ndarray:
     """
     Tool to keep round a float to n decimal places.
 
@@ -504,7 +517,9 @@ def round_to_n_decimal_places(array: float | np.ndarray, n: int = 3) -> float | 
 class TablePrinter:
     """Print a list of dicts as a table."""
 
-    def __init__(self, fmt: list[tuple[str, str, int]], sep: str = " ", ul: str | None = None) -> None:
+    def __init__(
+        self, fmt: list[tuple[str, str, int]], sep: str = " ", ul: str | None = None
+    ) -> None:
         """
         @param fmt: list of tuple(heading, key, width)
                         heading: str, column label
@@ -900,7 +915,11 @@ def flatten(iterable: Any) -> Any:
         return iterable
 
 
-def tensor_product(a: np.ndarray | sp.sparse.sparray, b: np.ndarray | sp.sparse.sparray, reshape: bool = True) -> np.ndarray:
+def tensor_product(
+    a: np.ndarray | sp.sparse.sparray,
+    b: np.ndarray | sp.sparse.sparray,
+    reshape: bool = True,
+) -> np.ndarray:
     """
     Compute the tensor protuct of two matrices a and b.
 


### PR DESCRIPTION
While reading the codebase, I notices it barely has type hints across all the files.
In this pull request I tried to add a comprehensive and declarative type hints for the `pygam` main directory for better readability and usability.
This PR covered the following files:
`Terms`, `callbacks`, `core`, `distributions`, `links`, `penalties`, `utils`. 