### PR TITLE
fix: weighted loglikelihood wrong for LinearGAM with non-uniform weights

### DIFF
--- a/pygam/distributions.py
+++ b/pygam/distributions.py
@@ -127,7 +127,7 @@ class NormalDist(Distribution):
         """
         if weights is None:
             weights = np.ones_like(mu)
-        scale = self.scale / weights
+        scale = self.scale / np.sqrt(weights)
         return sp.stats.norm.logpdf(y, loc=mu, scale=scale)
 
     @divide_weights

--- a/pygam/tests/test_distributions.py
+++ b/pygam/tests/test_distributions.py
@@ -1,0 +1,53 @@
+import numpy as np
+import pytest
+import scipy.stats
+
+from pygam.distributions import NormalDist
+
+
+def test_normal_log_pdf_weights_match_scipy():
+    """
+    check that NormalDist.log_pdf with non-unit weights agrees with scipy.
+
+    the GLM convention is Var = scale^2 / w, so SD = scale / sqrt(w).
+    """
+    dist = NormalDist(scale=1.0)
+    y = np.array([0.0])
+    mu = np.array([0.0])
+    w = np.array([4.0])
+
+    result = dist.log_pdf(y, mu, weights=w)
+    ref = scipy.stats.norm.logpdf(0.0, loc=0.0, scale=1.0 / np.sqrt(4.0))
+
+    np.testing.assert_allclose(result, ref, rtol=1e-12)
+
+
+def test_normal_log_pdf_unit_weights():
+    """
+    weights=1 should give the same result as weights=None
+    """
+    dist = NormalDist(scale=2.0)
+    y = np.array([1.0, 2.0, 3.0])
+    mu = np.array([1.5, 2.5, 2.0])
+
+    a = dist.log_pdf(y, mu, weights=None)
+    b = dist.log_pdf(y, mu, weights=np.ones(3))
+
+    np.testing.assert_allclose(a, b, rtol=1e-12)
+
+
+@pytest.mark.parametrize("scale", [0.5, 1.0, 3.0])
+@pytest.mark.parametrize("w", [0.25, 1.0, 4.0, 16.0])
+def test_normal_log_pdf_various_scales_and_weights(scale, w):
+    """
+    check against scipy for a range of scale and weight combos
+    """
+    dist = NormalDist(scale=scale)
+    y = np.array([1.0])
+    mu = np.array([0.0])
+
+    result = dist.log_pdf(y, mu, weights=np.array([w]))
+    sd = scale / np.sqrt(w)
+    ref = scipy.stats.norm.logpdf(1.0, loc=0.0, scale=sd)
+
+    np.testing.assert_allclose(result, ref, rtol=1e-12)


### PR DESCRIPTION
Noticed this while looking at how the weighted loglikelihood was being computed.

In `NormalDist.log_pdf`, the effective scale passed to scipy is `self.scale / weights`. That means the variance ends up being `scale² / w²`, but everywhere else in the codebase  `V()`, `phi()`, `_W()` -> the convention is `Var = scale² / w` (weights divide variance, not SD). So `log_pdf` was the odd one out.

The fix is one line:

```python
# before
scale = self.scale / weights

# after
scale = self.scale / np.sqrt(weights)
```

In practice this only matters when you're passing non-uniform sample weights to a `LinearGAM`. The fitted coefficients are fine since PIRLS uses `V()` and `_W()` which already handle weights correctly , it's just the loglikelihood that was wrong, and by extension AIC, AICc, GCV, and pseudo R².

Quick sanity check showing the old behaviour:

```python
from pygam.distributions import NormalDist
import numpy as np, scipy.stats

dist = NormalDist(scale=1.0)
print(dist.log_pdf(np.array([0.]), np.array([0.]), weights=np.array([4.])))
# was: 0.467  (positive log-pdf for a standard normal at its mean , clearly wrong)
# now: -0.226 (matches scipy.stats.norm.logpdf(0, loc=0, scale=0.5))
```

Added a small test file covering the basic weight convention, unit-weight sanity, and a parametrized sweep over a few scale/weight combos.

Closes #457
