### PR TITLE
fix:get_params returns copy preventing state mutation along with adding tests

### DIFF
--- a/pygam/core.py
+++ b/pygam/core.py
@@ -150,7 +150,7 @@ class Core:
         -------
         dict
         """
-        attrs = self.__dict__
+        attrs = dict(self.__dict__)
         for attr in self._include:
             attrs[attr] = getattr(self, attr)
 

--- a/pygam/tests/test_GAM_methods.py
+++ b/pygam/tests/test_GAM_methods.py
@@ -281,6 +281,14 @@ def test_get_params():
     params = gam.get_params()
     assert params["lam"] == 420
 
+def test_get_params_deep_true_returns_copy():
+    gam = LinearGAM()
+    original_max_iter = gam.max_iter
+
+    params = gam.get_params(deep=True)
+    params["max_iter"] = 1
+
+    assert gam.max_iter == original_max_iter
 
 class TestSamplingFromPosterior:
     def test_drawing_samples_from_unfitted_model(self, mcycle_X_y, mcycle_gam):

--- a/pygam/tests/test_core.py
+++ b/pygam/tests/test_core.py
@@ -30,3 +30,34 @@ def test_nice_repr_more_attrs():
     param_kvs = {"color": "blue", "n_ears": 3, "height": 1.3336}
     out = nice_repr("hi", param_kvs, line_width=60, line_offset=5, decimals=3)
     assert out == "hi(color='blue', height=1.334, n_ears=3)"
+
+
+def test_get_params_deep_true_returns_copy():
+    c = Core(name="cat", line_width=70, line_offset=3)
+    params = c.get_params(deep=True)
+
+    assert params is not c.__dict__
+    params["_name"] = "dog"
+    assert c._name == "cat"
+
+
+def test_get_params_default_does_not_mutate_dict_with_include():
+    class DemoCore(Core):
+        def __init__(self):
+            self.foo = 1
+            self._include = ["bar"]
+            super().__init__()
+
+        @property
+        def bar(self):
+            return 2
+
+    c = DemoCore()
+    assert "bar" not in c.__dict__
+
+    params = c.get_params()
+
+    assert params["foo"] == 1
+    assert params["bar"] == 2
+    assert "bar" not in c.__dict__
+


### PR DESCRIPTION
Hi @cbrummitt @fkiraly @dswah , I have made the following changes in the codebase which Closes #496

1. I have changed core.py file `attrs = self.__dict__` to `attrs = dict(self.__dict__)` , this prevents `get_params` from mutating object state during read and prevents `deep=True` to return a live internal dict that external callers can mutate.

2. I have also added core-level regression tests in the pygam/tests/test_core.py and model-level regression test in pygam/tests/test_GAM_methods.py file in order to check the approach.

For Validation I ran  `python -m pytest pygam/tests/test_core.py pygam/tests/test_GAM_methods.py -k get_params -p no:cacheprovider` to specially run the tests and I am attaching the screenshot of successfully passing them as well .
<img width="1092" height="298" alt="image" src="https://github.com/user-attachments/assets/64f1c331-fc73-4f6c-b5b5-3985e19cf3e7" />

Please guide me for any further changes. I would be happy to do them.
Thanks