### PR TITLE
feat: summary() returns dict of stats along with printing and added validation tests #315

### DIFF
--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -1647,14 +1647,34 @@ class GAM(Core, MetaTermMixin):
 
         Returns
         -------
-        None
+        stats_dict : dict
+            A dictionary containing the model and term statistics.
         """
         if not self._is_fitted:
             raise AttributeError("GAM has not been fitted. Call fit first.")
 
+        # Initialising the dict
+        stats_dict = {"model": {}, "terms": []}
+
         # high-level model summary
         width_details = 47
         width_results = 58
+
+        objective = "UBRE" if self.distribution._known_scale else "GCV"
+
+        stats_dict["model"]["distribution"] = self.distribution.__class__.__name__
+        stats_dict["model"]["edof"] = self.statistics_["edof"]
+        stats_dict["model"]["link"] = self.link.__class__.__name__
+        stats_dict["model"]["loglikelihood"] = self.statistics_["loglikelihood"]
+        stats_dict["model"]["n_samples"] = self.statistics_["n_samples"]
+        stats_dict["model"]["AIC"] = self.statistics_["AIC"]
+        stats_dict["model"]["AICc"] = self.statistics_["AICc"]
+        stats_dict["model"]["objective"] = objective
+        stats_dict["model"]["objective_value"] = self.statistics_[objective]
+        stats_dict["model"]["scale"] = self.statistics_["scale"]
+        stats_dict["model"]["pseudo_r2"] = self.statistics_["pseudo_r2"][
+            "explained_deviance"
+        ]
 
         model_fmt = [
             (self.__class__.__name__, "model_details", width_details),
@@ -1662,8 +1682,6 @@ class GAM(Core, MetaTermMixin):
         ]
 
         model_details = []
-
-        objective = "UBRE" if self.distribution._known_scale else "GCV"
 
         model_details.append(
             {
@@ -1754,8 +1772,11 @@ class GAM(Core, MetaTermMixin):
             # we cant get the edof per term
             if len(self.statistics_["edof_per_coef"]) == len(self.coef_):
                 idx = self.terms.get_coef_indices(i)
-                edof = np.round(self.statistics_["edof_per_coef"][idx].sum(), 1)
+                # capturing the RAW number for the dictionary
+                raw_edof = self.statistics_["edof_per_coef"][idx].sum()
+                edof = np.round(raw_edof, 1)
             else:
+                raw_edof = None
                 edof = ""
 
             term_data = {
@@ -1766,6 +1787,16 @@ class GAM(Core, MetaTermMixin):
                 "p_value": "%.2e" % (self.statistics_["p_values"][i]),
                 "sig_code": sig_code(self.statistics_["p_values"][i]),
             }
+
+            stats_dict["terms"].append(
+                {
+                    "feature": repr(term),
+                    "lam": term.lam if not term.isintercept else None,
+                    "rank": term.n_coefs,
+                    "edof": raw_edof,
+                    "p_value": self.statistics_["p_values"][i],
+                }
+            )
 
             data.append(term_data)
 
@@ -1804,6 +1835,8 @@ class GAM(Core, MetaTermMixin):
             "github.com/dswah/pyGAM/issues/163 \n",
             stacklevel=2,
         )
+
+        return stats_dict
 
     def gridsearch(
         self,

--- a/pygam/tests/test_summary_return.py
+++ b/pygam/tests/test_summary_return.py
@@ -1,0 +1,37 @@
+import numpy as np
+
+from pygam import LinearGAM, s
+
+
+def test_summary_returns_dictionary():
+    """
+    Test that the summary() method returns a dictionary containing
+    the correct model and term statistics.
+    """
+    # Setup: Create a simple model
+    X = np.random.rand(100, 1)
+    y = np.random.rand(100)
+    gam = LinearGAM(s(0)).fit(X, y)
+
+    # Execution: Call the method we refactored
+    res = gam.summary()
+
+    # Check that it is a dictionary
+    assert isinstance(res, dict)
+
+    # Check that top-level model keys exist
+    assert "model" in res
+    assert "terms" in res
+
+    # Check that raw data matches internal statistics
+    assert res["model"]["AIC"] == gam.statistics_["AIC"]
+    assert res["model"]["loglikelihood"] == gam.statistics_["loglikelihood"]
+
+    # Check that term-level data is captured
+    assert len(res["terms"]) == len(gam.terms)
+
+    # Cross-check EDoF precision (rounded in table, raw in dict)
+    dict_edof = res["terms"][0]["edof"]
+    stat_edof = gam.statistics_["edof_per_coef"][gam.terms.get_coef_indices(0)].sum()
+
+    assert np.isclose(dict_edof, stat_edof)


### PR DESCRIPTION
Fixes #315 

This PR addresses the issue by modifying the `summary()` method to return a dictionary containing model and term statistics.

### Changes
- Updated `summary()` to create and return `stats_dict`.
- I made sure to store the actual numbers for things like AIC and EDoF, so they stay accurate if someone wants to use them in a script.
- Updated the function comments to show that it returns a dictionary now.
- Added a new test file `pygam/tests/test_summary_return.py` to make sure the dictionary is returning the right numbers from the model.

### Why this is a good modification
Currently, the `summary()` method only prints information to the console. But if someone wants to use values like the AIC or p-values in a loop to compare a bunch of different models, they have to copy the numbers by hand.

By having the function return a dictionary, it's much easier to work with the data in code or save it for later. I also made sure to keep the full numbers (not just the rounded ones in the table) so they stay accurate for calculations.

**No changes to current functionality**
I was careful to make sure this doesn't break anything for existing users. The table still prints in the console exactly as it did before.

If someone doesn't want or needs the dictionary, they can just call `gam.summary()` like they always have. In Python, if you don't assign the output of a function to a variable, the return value is just ignored, so it won't affect their workflow or clutter their terminal. This makes the change purely additive.

### Testing
- Full test suite passed locally (including the new validation test).
- I also checked that the printed table still looks exactly the same as before.