### PR TITLE
Fix InvGaussDist.sample crash when scale=None

### DIFF
--- a/pygam/distributions.py
+++ b/pygam/distributions.py
@@ -609,7 +609,8 @@ class InvGaussDist(Distribution):
         -------
         random_samples : np.array of same shape as mu
         """
-        return np.random.wald(mean=mu, scale=self.scale, size=None)
+        scale = self.scale if self.scale is not None else 1.0
+        return np.random.wald(mean=mu, scale=scale, size=None)
 
 
 DISTRIBUTIONS = {

--- a/pygam/tests/test_distributions.py
+++ b/pygam/tests/test_distributions.py
@@ -1,0 +1,7 @@
+def test_invgauss_sample_with_default_scale():
+    from pygam.distributions import InvGaussDist
+
+    dist = InvGaussDist(scale=None)
+    sample = dist.sample(mu=1.0)
+
+    assert sample is not None


### PR DESCRIPTION

This PR fixes a runtime crash in InvGaussDist.sample when scale=None.
Problem :-
InvGaussDist.sample passed self.scale directly to numpy.random.wald. Since the default value of scale is None, NumPy raises:
TypeError: must be real number, not NoneType

Fix
Add a fallback when self.scale is None:
scale = self.scale if self.scale is not None else 1.0
return np.random.wald(mean=mu, scale=scale, size=None)

Tests
Added a regression test to ensure sampling works correctly when scale=None.
All existing tests pass locally (163 passed, 1 skipped).
