### PR TITLE
Fix #303: align edof_per_coef length with coefficients

### DIFF
--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -1030,7 +1030,11 @@ class GAM(Core, MetaTermMixin):
         """
         lp = self._linear_predictor(modelmat=modelmat)
         mu = self.link.mu(lp, self.distribution)
-        self.statistics_["edof_per_coef"] = np.diagonal(U1.dot(U1.T))
+        edof_per_coef = np.diagonal(U1.dot(U1.T))
+        n_missing = len(self.coef_) - len(edof_per_coef)
+        if n_missing > 0:
+            edof_per_coef = np.pad(edof_per_coef, (0, n_missing), mode="constant")
+        self.statistics_["edof_per_coef"] = edof_per_coef
         self.statistics_["edof"] = self.statistics_["edof_per_coef"].sum()
         if not self.distribution._known_scale:
             self.distribution.scale = (

--- a/pygam/tests/test_GAM_methods.py
+++ b/pygam/tests/test_GAM_methods.py
@@ -100,10 +100,7 @@ def test_more_splines_than_samples(mcycle_X_y):
     gam = LinearGAM(s(0, n_splines=n + 1)).fit(X, y)
     assert gam._is_fitted
 
-    # TODO here is our bug:
-    # we cannot display the term-by-term effective DoF because we have fewer
-    # values than coefficients
-    assert len(gam.statistics_["edof_per_coef"]) < len(gam.coef_)
+    assert len(gam.statistics_["edof_per_coef"]) == len(gam.coef_)
     gam.summary()
 
 

--- a/pygam/tests/test_gen_imgs.py
+++ b/pygam/tests/test_gen_imgs.py
@@ -1,4 +1,7 @@
+import matplotlib
 from unittest.mock import patch
+
+matplotlib.use("Agg")
 
 # Import the function to test
 import gen_imgs

--- a/pygam/tests/test_gen_imgs.py
+++ b/pygam/tests/test_gen_imgs.py
@@ -1,5 +1,6 @@
-import matplotlib
 from unittest.mock import patch
+
+import matplotlib
 
 matplotlib.use("Agg")
 


### PR DESCRIPTION
## Summary
Fixes the `edof_per_coef` length mismatch described in #303 so `summary()` can report term-level effective DoF consistently.

## Story / Investigation
- **Bug observed:** In high-spline, rank-deficient fits, `len(gam.statistics_["edof_per_coef"]) < len(gam.coef_)`.
- **Reproduction attempts:**
  1. Fit `PoissonGAM(n_splines=25)` on a small synthetic dataset.
  2. Print lengths of `edof_per_coef` and `coef_`.
  3. Call `gam.summary()` and observe missing term-level EDoF output.
- **Root cause:** `_estimate_model_statistics` stores `np.diagonal(U1.dot(U1.T))` directly, which can be shorter than coefficient count when rank drops.
- **Fix:** Pad the per-coefficient EDoF vector with trailing zeros to `len(coef_)` before assigning `statistics_["edof_per_coef"]`.

## Tests
- Updated `test_more_splines_than_samples` to assert aligned lengths.
- Ran:
  - `pytest -q pygam/tests/test_GAM_methods.py -k more_splines_than_samples`
