### PR TITLE
Fix #422: add __sklearn_tags__ for GAM and LogisticGAM

### DIFF
--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -937,6 +937,17 @@ class GAM(Core, MetaTermMixin):
 
         return r2["explained_deviance"]
 
+    def __sklearn_tags__(self):
+        """Return sklearn estimator tags for compatibility with sklearn>=1.7."""
+        from sklearn.utils._tags import InputTags, RegressorTags, Tags, TargetTags
+
+        return Tags(
+            estimator_type="regressor",
+            target_tags=TargetTags(required=True),
+            regressor_tags=RegressorTags(),
+            input_tags=InputTags(two_d_array=True, categorical=True, string=True),
+        )
+
     def deviance_residuals(self, X, y, weights=None, scaled=False):
         """
         Method to compute the deviance residuals of the model.
@@ -2648,6 +2659,17 @@ class LogisticGAM(GAM):
 
         """
         return self.accuracy(X, y, None)
+
+    def __sklearn_tags__(self):
+        """Return classifier tags for sklearn compatibility."""
+        from sklearn.utils._tags import ClassifierTags, InputTags, Tags, TargetTags
+
+        return Tags(
+            estimator_type="classifier",
+            target_tags=TargetTags(required=True),
+            classifier_tags=ClassifierTags(),
+            input_tags=InputTags(two_d_array=True, categorical=True, string=True),
+        )
 
     def predict(self, X):
         """

--- a/pygam/tests/test_GAM_methods.py
+++ b/pygam/tests/test_GAM_methods.py
@@ -64,6 +64,17 @@ def test_PoissonGAM_loglike(coal_X_y):
     ) < gam_low_var.loglikelihood(X, y, exposure)
 
 
+def test_sklearn_tags_are_exposed():
+    pytest.importorskip("sklearn")
+    from sklearn.utils._tags import get_tags
+
+    gam_tags = get_tags(GAM())
+    assert gam_tags.estimator_type == "regressor"
+
+    cls_tags = get_tags(LogisticGAM())
+    assert cls_tags.estimator_type == "classifier"
+
+
 def test_large_GAM():
     """
     check that we can fit a GAM in py3 when we have more than 50,000 samples


### PR DESCRIPTION
## Summary
Adds sklearn tag compatibility for pyGAM estimators to fix `get_tags` failures tracked in #422 (and related #481 behavior).

## Story / Investigation
- **Bug observed:** `sklearn.utils._tags.get_tags(GAM())` fails with `AttributeError: '__sklearn_tags__'` on newer sklearn versions.
- **Reproduction attempts:**
  1. Install sklearn 1.8 in a pyGAM dev environment.
  2. Run `get_tags(GAM())` and `get_tags(LogisticGAM())`.
  3. Observe crash from missing estimator tag method.
- **Root cause:** pyGAM estimator classes did not define sklearn’s expected `__sklearn_tags__` API.
- **Fix:** Implement `__sklearn_tags__` on:
  - `GAM` (regressor tags),
  - `LogisticGAM` (classifier tags).

## Tests
- Added `test_sklearn_tags_are_exposed`.
- Ran:
  - `pytest -q pygam/tests/test_GAM_methods.py -k sklearn_tags_are_exposed`
