### PR TITLE
Fix #322: support string categories in FactorTerm

### DIFF
--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -882,7 +882,13 @@ class GAM(Core, MetaTermMixin):
 
         # validate data
         y = check_y(y, self.link, self.distribution, verbose=self.verbose)
-        X = check_X(X, verbose=self.verbose)
+        check_X_kwargs = {"verbose": self.verbose}
+        if self._has_terms() and np.asarray(X).dtype.kind not in ["i", "f"]:
+            has_categorical = "categorical" in flatten(self.dtype)
+            if has_categorical:
+                check_X_kwargs["dtypes"] = self.dtype
+                check_X_kwargs["features"] = self.feature
+        X = check_X(X, **check_X_kwargs)
         check_X_y(X, y)
 
         if weights is not None:
@@ -1924,7 +1930,13 @@ class GAM(Core, MetaTermMixin):
             self._validate_params()
 
         y = check_y(y, self.link, self.distribution, verbose=self.verbose)
-        X = check_X(X, verbose=self.verbose)
+        check_X_kwargs = {"verbose": self.verbose}
+        if self._has_terms() and np.asarray(X).dtype.kind not in ["i", "f"]:
+            has_categorical = "categorical" in flatten(self.dtype)
+            if has_categorical:
+                check_X_kwargs["dtypes"] = self.dtype
+                check_X_kwargs["features"] = self.feature
+        X = check_X(X, **check_X_kwargs)
         check_X_y(X, y)
 
         # special checks if model not fitted

--- a/pygam/terms.py
+++ b/pygam/terms.py
@@ -1011,6 +1011,7 @@ class FactorTerm(SplineTerm):
         self, feature, lam=0.6, penalties="auto", coding="one-hot", verbose=False
     ):
         self.coding = coding
+        self.categories_ = None
         super(FactorTerm, self).__init__(
             feature=feature,
             lam=lam,
@@ -1066,12 +1067,21 @@ class FactorTerm(SplineTerm):
         -------
         None
         """
-        super(FactorTerm, self).compile(X)
+        if self.feature >= X.shape[1]:
+            raise ValueError(
+                f"term requires feature {self.feature}, but X has only {X.shape[1]} dimensions"
+            )
 
-        self.n_splines = len(np.unique(X[:, self.feature]))
-        self.edge_knots_ = gen_edge_knots(
-            X[:, self.feature], self.dtype, verbose=verbose
-        )
+        raw = np.asarray(X[:, self.feature])
+        if raw.dtype.kind in ["i", "f"]:
+            encoded = raw.astype("float")
+            self.categories_ = None
+        else:
+            self.categories_, encoded = np.unique(raw, return_inverse=True)
+            encoded = encoded.astype("float")
+
+        self.n_splines = len(np.unique(encoded))
+        self.edge_knots_ = gen_edge_knots(encoded, self.dtype, verbose=verbose)
         return self
 
     def build_columns(self, X, verbose=False):
@@ -1089,7 +1099,31 @@ class FactorTerm(SplineTerm):
         -------
         scipy sparse array with n rows
         """
-        columns = super(FactorTerm, self).build_columns(X, verbose=verbose)
+        raw = np.asarray(X[:, self.feature])
+        if self.categories_ is None:
+            encoded = raw.astype("float")
+        else:
+            idx = np.searchsorted(self.categories_, raw)
+            in_bounds = idx < len(self.categories_)
+            matches = np.zeros_like(in_bounds, dtype=bool)
+            matches[in_bounds] = self.categories_[idx[in_bounds]] == raw[in_bounds]
+            unseen = ~matches
+            if unseen.any():
+                unseen_values = np.unique(raw[unseen]).tolist()
+                raise ValueError(
+                    f"X data has categories not seen during fit for feature {self.feature}: {unseen_values}"
+                )
+            encoded = idx.astype("float")
+
+        columns = b_spline_basis(
+            encoded,
+            edge_knots=self.edge_knots_,
+            spline_order=self.spline_order,
+            n_splines=self.n_splines,
+            sparse=True,
+            periodic=self.basis in ["cp"],
+            verbose=verbose,
+        )
         if self.coding == "dummy":
             columns = columns[:, 1:]
 

--- a/pygam/tests/test_terms.py
+++ b/pygam/tests/test_terms.py
@@ -230,6 +230,43 @@ def test_dummy_encoding(wage_X_y, wage_gam):
     assert wage_gam.terms[2].n_coefs == 5
 
 
+def test_factor_term_supports_string_categories():
+    X = np.array(
+        [
+            [0.1, 1.0, "GitHub"],
+            [0.2, 2.0, "GitLab"],
+            [0.3, 3.0, "GitHub"],
+            [0.4, 4.0, "Bitbucket"],
+        ],
+        dtype=object,
+    )
+    y = np.array([1.0, 2.0, 1.5, 0.8])
+
+    gam = LinearGAM(f(2, coding="one-hot")).fit(X, y)
+
+    assert gam._is_fitted
+    assert gam.terms[0].n_coefs == 3
+
+
+def test_factor_term_rejects_unseen_string_categories():
+    X = np.array(
+        [
+            [0.1, 1.0, "GitHub"],
+            [0.2, 2.0, "GitLab"],
+            [0.3, 3.0, "GitHub"],
+            [0.4, 4.0, "Bitbucket"],
+        ],
+        dtype=object,
+    )
+    y = np.array([1.0, 2.0, 1.5, 0.8])
+
+    gam = LinearGAM(f(2, coding="one-hot")).fit(X, y)
+    X_new = np.array([[0.6, 2.0, "SourceHut"]], dtype=object)
+
+    with pytest.raises(ValueError, match="not seen during fit"):
+        gam.predict(X_new)
+
+
 def test_build_cyclic_p_spline(hepatitis_X_y):
     """check the cyclic p spline builds
 

--- a/pygam/utils.py
+++ b/pygam/utils.py
@@ -288,21 +288,59 @@ def check_X(
     if bool(features):
         features = flatten(features)
         max_feat = max(flatten(features))
+        required_feats = max_feat + 1
 
         if n_feats is None:
-            n_feats = max_feat
+            n_feats = required_feats
 
-        n_feats = max(n_feats, max_feat)
+        n_feats = max(n_feats, required_feats)
+
+    dtypes_flat = flatten(dtypes) if dtypes is not None else []
+    features_flat = flatten(features) if features is not None else []
+    categorical_features = {
+        feat for feat, dt in zip(features_flat, dtypes_flat) if dt == "categorical"
+    }
+    has_categorical = len(categorical_features) > 0
+    is_non_numeric_input = np.asarray(X).dtype.kind not in ["i", "f"]
 
     # basic diagnostics
-    X = check_array(
-        X,
-        force_2d=True,
-        n_feats=n_feats,
-        min_samples=min_samples,
-        name="X data",
-        verbose=verbose,
-    )
+    if has_categorical and is_non_numeric_input:
+        X = make_2d(X, verbose=verbose).astype(object, copy=False)
+
+        if n_feats is not None:
+            m = X.shape[1]
+            if m != n_feats:
+                raise ValueError(f"X data must have {n_feats} features, but found {m}")
+
+        n = X.shape[0]
+        if n < min_samples:
+            raise ValueError(
+                f"X data should have at least {min_samples} samples, but found {n}"
+            )
+
+        for feature in range(X.shape[1]):
+            if feature in categorical_features:
+                continue
+
+            try:
+                X[:, feature] = np.asarray(X[:, feature]).astype("float")
+            except (ValueError, TypeError):
+                raise ValueError(
+                    "X data must be type int or float on non-categorical features, "
+                    f"but feature {feature} cannot be converted"
+                )
+
+            if not np.isfinite(np.asarray(X[:, feature], dtype="float")).all():
+                raise ValueError("X data must not contain Inf nor NaN")
+    else:
+        X = check_array(
+            X,
+            force_2d=True,
+            n_feats=n_feats,
+            min_samples=min_samples,
+            name="X data",
+            verbose=verbose,
+        )
 
     # check our categorical data has no new categories
     if (edge_knots is not None) and (dtypes is not None) and (features is not None):
@@ -324,13 +362,20 @@ def check_X(
             if dt == "categorical":
                 min_ = ek[0]
                 max_ = ek[-1]
-                if (np.unique(x) < min_).any() or (np.unique(x) > max_).any():
+                # Numeric categorical features can be checked directly.
+                # String/object categoricals are validated at the term level.
+                try:
+                    numeric_x = np.unique(np.asarray(x).astype("float"))
+                except (TypeError, ValueError):
+                    continue
+
+                if (numeric_x < min_).any() or (numeric_x > max_).any():
                     min_ += 0.5
                     max_ -= 0.5
                     raise ValueError(
                         "X data is out of domain for categorical "
                         f"feature {i}. Expected data on [{min_}, {max_}], "
-                        f"but found data on [{x.min()}, {x.max()}]"
+                        f"but found data on [{numeric_x.min()}, {numeric_x.max()}]"
                     )
 
     return X


### PR DESCRIPTION
## Summary
Fixes #322 by supporting string/object categorical values for `FactorTerm` with one-hot coding and explicit unseen-category validation.

## Story / Investigation
- **Bug observed:** `LinearGAM(f(2, coding="one-hot")).fit(X, y)` fails when `X[:, 2]` contains strings.
- **Reproduction attempts:**
  1. Build a mixed `dtype=object` matrix with numeric columns plus a string categorical column.
  2. Fit `LinearGAM(f(2, coding="one-hot"))`.
  3. Observe `ValueError` from global numeric coercion (`X data must be type int or float`).
- **Root cause:**
  - `check_X` coerces object arrays to numeric globally.
  - `FactorTerm` compilation/build logic assumes already numeric categories.
- **Fix:**
  - Add categorical-aware object input handling in `check_X` (preserve categorical column, validate numeric convertibility for non-categorical columns).
  - Teach `FactorTerm` to encode string categories at fit time and map them consistently at predict time.
  - Raise clear error on unseen categories at prediction.

## Tests
- Added:
  - `test_factor_term_supports_string_categories`
  - `test_factor_term_rejects_unseen_string_categories`
- Ran full suite:
  - `pytest -q`
