### PR TITLE
fix: NormalDist.log_pdf weight application (#457)

### DIFF
--- a/pygam/distributions.py
+++ b/pygam/distributions.py
@@ -127,7 +127,7 @@ class NormalDist(Distribution):
         """
         if weights is None:
             weights = np.ones_like(mu)
-        scale = self.scale / weights
+        scale = self.scale / np.sqrt(weights)
         return sp.stats.norm.logpdf(y, loc=mu, scale=scale)
 
     @divide_weights

--- a/pygam/tests/conftest.py
+++ b/pygam/tests/conftest.py
@@ -1,3 +1,7 @@
+import matplotlib
+
+matplotlib.use("Agg")  # Force non-interactive backend for headless CI environments
+
 import pytest
 
 from pygam import (

--- a/pygam/tests/test_GAMs.py
+++ b/pygam/tests/test_GAMs.py
@@ -111,4 +111,30 @@ def test_ExpectileGAM_bad_expectiles(mcycle_X_y):
         ExpectileGAM(expectile=1.1).fit(X, y)
 
 
+def test_normal_dist_log_pdf_weights():
+    """
+    Regression test for Issue #457: NormalDist.log_pdf must apply
+    weights to variance, not linearly to standard deviation.
+    """
+    import numpy as np
+    import scipy.stats as st
+
+    from pygam.distributions import NormalDist
+
+    scale = 1.0
+    weights = np.array([4.0])
+    y = np.array([0.0])
+    mu = np.array([0.0])
+
+    dist = NormalDist(scale=scale)
+    actual = dist.log_pdf(y, mu, weights=weights)[0]
+
+    # Standard deviation used by scipy should be scale / sqrt(w)
+    # For scale=1, w=4, the SD is 0.5
+    expected_sd = scale / np.sqrt(weights)
+    expected = st.norm.logpdf(y, loc=mu, scale=expected_sd)[0]
+
+    assert np.isclose(actual, expected), f"Expected {expected}, but got {actual}"
+
+
 # TODO check dicts: DISTRIBUTIONS etc

--- a/pygam/tests/test_gen_imgs.py
+++ b/pygam/tests/test_gen_imgs.py
@@ -1,3 +1,7 @@
+import matplotlib
+
+matplotlib.use("Agg")
+
 from unittest.mock import patch
 
 # Import the function to test


### PR DESCRIPTION
## Description
Fixes #457.

This PR corrects the mathematical application of sample weights in `NormalDist.log_pdf`. In GLM conventions, weights $w$ should divide the variance ($\text{Var} = \sigma^2 / w$), which implies the standard deviation used in the PDF should be adjusted by the square root of the weight ($\text{SD} = \sigma / \sqrt{w}$).

## Changes
- **Distributions**: Updated `NormalDist.log_pdf` to divide the scale by `np.sqrt(weights)` to ensure statistical consistency with the rest of the library's PIRLS implementation.
- **Infrastructure**: Configured the `matplotlib` non-interactive `Agg` backend in `conftest.py` and `test_gen_imgs.py` to resolve the `_tkinter.TclError` (missing `init.tcl`) that causes failures on headless Windows CI runners.
- **Tests**: Added a regression test `test_normal_dist_log_pdf_weights` to `test_GAMs.py` that validates `log_pdf` output against `scipy.stats.norm.logpdf`.

## Testing Performed
- Verified fix with a standalone reproduction script (matches `scipy.stats`).
- Confirmed that the new regression test passes locally with `pytest`.
- Verified all 164 existing tests pass across platforms, resolving the Windows-specific failure.
- Verified code style compliance with `ruff format`.