### PR TITLE
fix(core): return deepcopy from get_params to prevent state mutation

### DIFF
--- a/pygam/core.py
+++ b/pygam/core.py
@@ -139,6 +139,24 @@ class Core:
             args=None,
         )
 
+    @staticmethod
+    def _maybe_deepcopy(v):
+        """Deepcopy only mutable types; return immutable scalars as-is.
+
+        Parameters
+        ----------
+        v : object
+            value to potentially copy
+
+        Returns
+        -------
+        object
+            a deepcopy of v if it is mutable, otherwise v itself
+        """
+        if isinstance(v, (int, float, bool, str, type(None))):
+            return v
+        return copy.deepcopy(v)
+
     def get_params(self, deep=False):
         """
         Returns a dict of all of the object's user-facing parameters.
@@ -157,14 +175,12 @@ class Core:
             attrs[attr] = getattr(self, attr)
 
         if deep is True:
-            return copy.deepcopy(attrs)
-        return dict(
-            [
-                (k, copy.deepcopy(v))
-                for k, v in list(attrs.items())
-                if (k[0] != "_") and (k[-1] != "_") and (k not in self._exclude)
-            ]
-        )
+            return {k: self._maybe_deepcopy(v) for k, v in attrs.items()}
+        return {
+            k: self._maybe_deepcopy(v)
+            for k, v in attrs.items()
+            if (k[0] != "_") and (k[-1] != "_") and (k not in self._exclude)
+        }
 
     def set_params(self, deep=False, force=False, **parameters):
         """

--- a/pygam/core.py
+++ b/pygam/core.py
@@ -1,6 +1,7 @@
 """Core Classes"""
 
 import numpy as np
+import copy
 
 from pygam.utils import flatten, round_to_n_decimal_places
 
@@ -155,10 +156,10 @@ class Core:
             attrs[attr] = getattr(self, attr)
 
         if deep is True:
-            return attrs
+            return copy.deepcopy(attrs)
         return dict(
             [
-                (k, v)
+                (k, copy.deepcopy(v))
                 for k, v in list(attrs.items())
                 if (k[0] != "_") and (k[-1] != "_") and (k not in self._exclude)
             ]

--- a/pygam/core.py
+++ b/pygam/core.py
@@ -1,7 +1,8 @@
 """Core Classes"""
 
-import numpy as np
 import copy
+
+import numpy as np
 
 from pygam.utils import flatten, round_to_n_decimal_places
 

--- a/pygam/tests/test_get_params.py
+++ b/pygam/tests/test_get_params.py
@@ -1,0 +1,34 @@
+import numpy as np
+
+import pytest
+
+from pygam import LinearGAM, s, f, te, intercept
+
+def test_get_params_returns_independent_copies():
+    # Issue #522: get_params() exposes mutable nested objects
+    # Creating a sample model with a combination of terms
+    np.random.seed(42)
+    X = np.random.randn(100, 2)
+    y = np.random.randn(100)
+    
+    # Adding string and number parameters
+    gam = LinearGAM(s(0) + f(1)).fit(X, y)
+    
+    # Retrieve the parameters dict
+    params = gam.get_params()
+    
+    # Grab the original value for lambda of the first term
+    original_lam = gam.terms[0].lam
+    
+    # Attempt to mutate the value in the returned dict
+    # This should NOT affect the underlying standard model configuration because it should be a deepcopy
+    params["terms"][0].lam = 9999.0
+    
+    # Assert that the model's actual parameter hasn't changed
+    assert gam.terms[0].lam == original_lam, "Modifying get_params() result inappropriately altered the model's term instances"
+    
+    # Additionally test array mutation
+    if hasattr(gam.terms[0], "edge_knots_"):
+        params["terms"][0].edge_knots_ = [100.0, 200.0]
+        assert np.any(gam.terms[0].edge_knots_ != [100.0, 200.0]), "Array modifications in get_params exposed model's internal data"
+

--- a/pygam/tests/test_get_params.py
+++ b/pygam/tests/test_get_params.py
@@ -1,8 +1,7 @@
 import numpy as np
 
-import pytest
+from pygam import LinearGAM, f, s
 
-from pygam import LinearGAM, s, f, te, intercept
 
 def test_get_params_returns_independent_copies():
     # Issue #522: get_params() exposes mutable nested objects
@@ -10,25 +9,28 @@ def test_get_params_returns_independent_copies():
     np.random.seed(42)
     X = np.random.randn(100, 2)
     y = np.random.randn(100)
-    
+
     # Adding string and number parameters
     gam = LinearGAM(s(0) + f(1)).fit(X, y)
-    
+
     # Retrieve the parameters dict
     params = gam.get_params()
-    
+
     # Grab the original value for lambda of the first term
     original_lam = gam.terms[0].lam
-    
+
     # Attempt to mutate the value in the returned dict
     # This should NOT affect the underlying standard model configuration because it should be a deepcopy
     params["terms"][0].lam = 9999.0
-    
+
     # Assert that the model's actual parameter hasn't changed
-    assert gam.terms[0].lam == original_lam, "Modifying get_params() result inappropriately altered the model's term instances"
-    
+    assert gam.terms[0].lam == original_lam, (
+        "Modifying get_params() result inappropriately altered the model's term instances"
+    )
+
     # Additionally test array mutation
     if hasattr(gam.terms[0], "edge_knots_"):
         params["terms"][0].edge_knots_ = [100.0, 200.0]
-        assert np.any(gam.terms[0].edge_knots_ != [100.0, 200.0]), "Array modifications in get_params exposed model's internal data"
-
+        assert np.any(gam.terms[0].edge_knots_ != [100.0, 200.0]), (
+            "Array modifications in get_params exposed model's internal data"
+        )

--- a/pygam/tests/test_get_params.py
+++ b/pygam/tests/test_get_params.py
@@ -34,3 +34,24 @@ def test_get_params_returns_independent_copies():
         assert np.any(gam.terms[0].edge_knots_ != [100.0, 200.0]), (
             "Array modifications in get_params exposed model's internal data"
         )
+
+
+def test_get_params_scalars_not_copied():
+    """Immutable scalar params should be returned as-is (no deepcopy overhead)."""
+    gam = LinearGAM()
+    params = gam.get_params()
+
+    # int, float, bool, str should be identical objects (not deepcopied)
+    assert params["max_iter"] is gam.max_iter
+    assert params["tol"] is gam.tol
+    assert params["verbose"] is gam.verbose
+    assert params["fit_intercept"] is gam.fit_intercept
+
+
+def test_get_params_lists_are_copied():
+    """Mutable list params like callbacks should be independent copies."""
+    gam = LinearGAM()
+    params = gam.get_params()
+
+    assert params["callbacks"] is not gam.callbacks
+    assert params["callbacks"] == gam.callbacks


### PR DESCRIPTION
# PR Title: Fix: `get_params` exposes mutable nested objects (#522)

## Description

This PR fixes issue #522, where `GAM.get_params()` exposes direct references to the `Term` and `TermList` objects through the parameter dictionary. Because of this, modifications to the returned dictionary such as `params["terms"][0].lam = ...` would silently mutate the underlying model's state, violating the scikit-learn estimator contract.

This is fixed by updating `Core.get_params()` to return `copy.deepcopy()` of the dictionary and nested lists/objects rather than returning direct referential dictionaries.

## Changes Made
* **`pygam/core.py`**: Added `import copy` and wrapped returned variables from `Core.get_params()` in `copy.deepcopy()`.
* **`pygam/tests/test_get_params.py`**: Introduced a new test file validating that external mutations to the dictionary returned by `get_params` do not change the underlying structure.

## Testing
- Extended the test suite with `test_get_params.py` (verified it appropriately captures parameter changes without model changes).
- Ran full regression testing suite (`pytest pygam/tests`); all passes. 
- Fully compatible with sklearn's `clone` logic.

Closes #522
