### PR TITLE
Fix: Prevent `InvGaussDist.sample` crash when `scale=None` (#505)

### DIFF
--- a/pygam/distributions.py
+++ b/pygam/distributions.py
@@ -609,7 +609,8 @@ class InvGaussDist(Distribution):
         -------
         random_samples : np.array of same shape as mu
         """
-        return np.random.wald(mean=mu, scale=self.scale, size=None)
+        scale = self.scale if self.scale is not None else 1.0
+        return np.random.wald(mean=mu, scale=scale, size=None)
 
 
 DISTRIBUTIONS = {

--- a/pygam/tests/test_distributions.py
+++ b/pygam/tests/test_distributions.py
@@ -1,15 +1,15 @@
 import numpy as np
-import pytest
 
 from pygam.distributions import InvGaussDist
+
 
 def test_inv_gauss_dist_sample_no_scale():
     # Issue #505: InvGaussDist.sample crashes when scale=None
     dist = InvGaussDist(scale=None)
-    
+
     # We expect `sample` to fall back to scale=1.0 and not raise a TypeError
     samples = dist.sample(mu=1.0)
-    
+
     # Assert we get a valid output
     assert samples is not None
     assert isinstance(samples, (float, np.ndarray))

--- a/pygam/tests/test_distributions.py
+++ b/pygam/tests/test_distributions.py
@@ -1,0 +1,15 @@
+import numpy as np
+import pytest
+
+from pygam.distributions import InvGaussDist
+
+def test_inv_gauss_dist_sample_no_scale():
+    # Issue #505: InvGaussDist.sample crashes when scale=None
+    dist = InvGaussDist(scale=None)
+    
+    # We expect `sample` to fall back to scale=1.0 and not raise a TypeError
+    samples = dist.sample(mu=1.0)
+    
+    # Assert we get a valid output
+    assert samples is not None
+    assert isinstance(samples, (float, np.ndarray))


### PR DESCRIPTION


This PR fixes issue #505 where `InvGaussDist.sample` crashes with a `TypeError` if its `scale` is explicitly `None` (which is its default constructor value).

The `sample()` method previously passed `self.scale` directly to `np.random.wald(scale=self.scale)`. When it received `None`, NumPy raised an error since it requires a numeric sequence. The fix intercepts a missing value and correctly passes a default scale of `1.0`.

## Changes Made
- Update `pygam/distributions.py` inside `InvGaussDist.sample()`: added logical check for `scale` such that it defaults to `1.0` if `self.scale` is `None` (analogous to implementations in `NormalDist`).
- Created `pygam/tests/test_distributions.py` including a new validation case strictly targeting the `.sample()` functionality on `InvGaussDist(scale=None)`.

Closes #505
