### PR TITLE
implementing automatic smoothening parameter selection

### DIFF
--- a/pygam/core.py
+++ b/pygam/core.py
@@ -150,7 +150,7 @@ class Core:
         -------
         dict
         """
-        attrs = self.__dict__
+        attrs = dict(self.__dict__)
         for attr in self._include:
             attrs[attr] = getattr(self, attr)
 

--- a/pygam/distributions.py
+++ b/pygam/distributions.py
@@ -159,6 +159,14 @@ class NormalDist(Distribution):
         """
         return np.ones_like(mu)
 
+    def V_prime(self, mu):
+        """First derivative of variance function wrt mu."""
+        return np.zeros_like(mu)
+
+    def V_double_prime(self, mu):
+        """Second derivative of variance function wrt mu."""
+        return np.zeros_like(mu)
+
     @multiply_weights
     def deviance(self, y, mu, scaled=True):
         """
@@ -263,6 +271,14 @@ class BinomialDist(Distribution):
         variance : np.array of length n
         """
         return mu * (1 - mu / self.levels)
+
+    def V_prime(self, mu):
+        """First derivative of variance function wrt mu."""
+        return 1 - 2 * mu / self.levels
+
+    def V_double_prime(self, mu):
+        """Second derivative of variance function wrt mu."""
+        return -2 * np.ones_like(mu) / self.levels
 
     @multiply_weights
     def deviance(self, y, mu, scaled=True):
@@ -369,6 +385,14 @@ class PoissonDist(Distribution):
         """
         return mu
 
+    def V_prime(self, mu):
+        """First derivative of variance function wrt mu."""
+        return np.ones_like(mu)
+
+    def V_double_prime(self, mu):
+        """Second derivative of variance function wrt mu."""
+        return np.zeros_like(mu)
+
     @multiply_weights
     def deviance(self, y, mu, scaled=True):
         """
@@ -465,6 +489,14 @@ class GammaDist(Distribution):
         variance : np.array of length n
         """
         return mu**2
+
+    def V_prime(self, mu):
+        """First derivative of variance function wrt mu."""
+        return 2 * mu
+
+    def V_double_prime(self, mu):
+        """Second derivative of variance function wrt mu."""
+        return 2 * np.ones_like(mu)
 
     @multiply_weights
     def deviance(self, y, mu, scaled=True):
@@ -568,6 +600,14 @@ class InvGaussDist(Distribution):
         variance : np.array of length n
         """
         return mu**3
+
+    def V_prime(self, mu):
+        """First derivative of variance function wrt mu."""
+        return 3 * mu**2
+
+    def V_double_prime(self, mu):
+        """Second derivative of variance function wrt mu."""
+        return 6 * mu
 
     @multiply_weights
     def deviance(self, y, mu, scaled=True):

--- a/pygam/links.py
+++ b/pygam/links.py
@@ -76,6 +76,14 @@ class IdentityLink(Link):
         """
         return np.ones_like(mu)
 
+    def g_double_prime(self, mu, dist):
+        """Second derivative of link wrt mu."""
+        return np.zeros_like(mu)
+
+    def g_triple_prime(self, mu, dist):
+        """Third derivative of link wrt mu."""
+        return np.zeros_like(mu)
+
 
 class LogitLink(Link):
     """
@@ -136,6 +144,22 @@ class LogitLink(Link):
         """
         return dist.levels / (mu * (dist.levels - mu))
 
+    def g_double_prime(self, mu, dist):
+        """Second derivative of link wrt mu."""
+        L = dist.levels
+        denom = (mu * (L - mu)) ** 2
+        return -L * (L - 2 * mu) / denom
+
+    def g_triple_prime(self, mu, dist):
+        """Third derivative of link wrt mu computed analytically."""
+        L = dist.levels
+        denom = mu * (L - mu)
+        # g'' = -L*(L-2mu)/(denom^2)
+        # differentiate using quotient/product rules
+        term1 = 2 * L * (L - 2 * mu) ** 2 / (denom**3)
+        term2 = 2 * L / (denom**2)
+        return term1 + term2
+
 
 class LogLink(Link):
     """
@@ -194,6 +218,14 @@ class LogLink(Link):
         grad : np.array of length n
         """
         return 1.0 / mu
+
+    def g_double_prime(self, mu, dist):
+        """Second derivative of link wrt mu."""
+        return -1.0 / (mu**2)
+
+    def g_triple_prime(self, mu, dist):
+        """Third derivative of link wrt mu."""
+        return 2.0 / (mu**3)
 
 
 class InverseLink(Link):
@@ -254,6 +286,12 @@ class InverseLink(Link):
         """
         return -1 * mu**-2.0
 
+    def g_double_prime(self, mu, dist):
+        return 2.0 * mu**-3.0
+
+    def g_triple_prime(self, mu, dist):
+        return -6.0 * mu**-4.0
+
 
 class InvSquaredLink(Link):
     """
@@ -312,6 +350,12 @@ class InvSquaredLink(Link):
         grad : np.array of length n
         """
         return -2 * mu**-3.0
+
+    def g_double_prime(self, mu, dist):
+        return 6.0 * mu**-4.0
+
+    def g_triple_prime(self, mu, dist):
+        return -24.0 * mu**-5.0
 
 
 LINKS = {

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -996,12 +996,10 @@ class GAM(Core, MetaTermMixin):
 
             # backtracking line search
             alpha = 1.0
-            improved = False
             while alpha > 1e-4:
                 trial_rho = rho + alpha * step
                 trial_val = obj(trial_rho)
                 if np.isfinite(trial_val) and trial_val < val:
-                    improved = True
                     rho = trial_rho
                     val = trial_val
                     break

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -9,6 +9,7 @@ import scipy as sp
 from progressbar import ProgressBar
 from scipy import stats  # noqa: F401
 
+import pygam.smooth_optimizer as smooth_opt
 from pygam.callbacks import (
     CALLBACKS,  # noqa: F401
     Accuracy,  # noqa: F401
@@ -821,6 +822,208 @@ class GAM(Core, MetaTermMixin):
         print("did not converge")
         return
 
+    # --- smoothing parameter (lambda) helpers ---
+    def _get_flat_lam(self):
+        """Return smoothing parameters as a 1D numpy array."""
+        if not self._has_terms():
+            return np.array([])
+        return np.asarray(flatten(self.lam), dtype=float)
+
+    def _set_flat_lam(self, lam_vec):
+        """Set smoothing parameters from a 1D array, broadcasting by term."""
+        lam_vec = np.asarray(lam_vec, dtype=float).ravel()
+        lam_vec = np.maximum(lam_vec, EPS)  # guard against zeros / negatives
+        expected = np.atleast_1d(flatten(self.lam)).size
+        if expected != lam_vec.size:
+            raise ValueError(
+                f"Expected {expected} smoothing parameters, but received {lam_vec.size}"
+            )
+        self.terms.lam = lam_vec.tolist()
+        return lam_vec
+
+    def _objective_value(self, objective):
+        """Return the active smoothing objective (GCV / UBRE)."""
+        if objective == "auto":
+            objective = "UBRE" if self.distribution._known_scale else "GCV"
+        if objective not in ("GCV", "UBRE"):
+            raise ValueError(
+                f"objective must be in ['GCV', 'UBRE', 'auto'], found {objective}"
+            )
+        value = self.statistics_.get(objective)
+        if value is None:
+            alt = "GCV" if objective == "UBRE" else "UBRE"
+            value = self.statistics_.get(alt)
+        return value
+
+    def _outer_lam_search(
+        self,
+        X,
+        y,
+        weights,
+        objective="auto",
+        max_iter=20,
+        tol=1e-3,
+        bounds=(-20, 20),
+    ):
+        """
+        Optimize smoothing parameters via an outer loop on log(lam).
+
+        Uses an L-BFGS-B search over log smoothing parameters, with the PIRLS
+        solver as the inner loop. Based on the outer-loop lambda updates
+        described in Wood (2008) "Fast stable direct fitting and smoothness
+        selection for Generalized Additive Models".
+        """
+        lam0 = self._get_flat_lam()
+        if lam0.size == 0:
+            return
+
+        # prepare bounds on log(lam)
+        if isinstance(bounds, tuple):
+            bounds = [bounds] * lam0.size
+        loglam0 = np.log(np.maximum(lam0, EPS))
+
+        def _eval(loglam):
+            """Objective wrapper for the optimizer."""
+            try:
+                lam = np.exp(loglam)
+                self._set_flat_lam(lam)
+                self._pirls(X, y, weights)
+                value = self._objective_value(objective)
+                if value is None or not np.isfinite(value):
+                    return np.inf
+                return value
+            except (ValueError, np.linalg.LinAlgError, NotPositiveDefiniteError):
+                return np.inf
+
+        res = sp.optimize.minimize(
+            _eval,
+            loglam0,
+            method="L-BFGS-B",
+            bounds=bounds,
+            options={"maxiter": max_iter, "ftol": tol},
+        )
+
+        # re-fit with the optimized lambdas to refresh statistics and logs
+        self._set_flat_lam(np.exp(res.x))
+        self._pirls(X, y, weights)
+        self.statistics_["lam_opt_result"] = res
+
+    def _dense_penalty(self, lam_vec=None):
+        """Return dense penalty matrix S for provided lambdas."""
+        if lam_vec is not None:
+            old = self._get_flat_lam()
+            self._set_flat_lam(lam_vec)
+        Pmat = self._P()
+        if sp.sparse.issparse(Pmat):
+            Pmat = Pmat.toarray()
+        if lam_vec is not None:
+            self._set_flat_lam(old)
+        return Pmat
+
+    def _objective_fn(self, X, y, weights, criterion="gcv", gamma=1.0):
+        """Return callable mapping rho -> objective value."""
+
+        def _obj(rho):
+            lam_vec = np.exp(rho)
+            self._set_flat_lam(lam_vec)
+            self._pirls(X, y, weights)
+            if criterion.lower() in ("gcv", "gcv_cp"):
+                val = self.statistics_.get("GCV")
+            elif criterion.lower() in ("ubre", "aic"):
+                val = (
+                    self.statistics_.get("UBRE")
+                    if self.distribution._known_scale
+                    else self.statistics_.get("AIC")
+                )
+            else:
+                raise ValueError("criterion must be in {'gcv','aic','ubre'}")
+            return np.inf if val is None else val
+
+        return _obj
+
+    def fit_auto_smooth(
+        self,
+        X,
+        y,
+        weights=None,
+        criterion="gcv",
+        gamma=1.0,
+        max_iter_outer=15,
+        tol_outer=1e-3,
+        fd_eps=1e-4,
+    ):
+        """
+        Automatic smoothness selection using an outer Newton loop on log-lambda.
+
+        This follows the Wood (2008) structure but computes derivatives via
+        finite differences around the stable PIRLS inner loop.
+        """
+        # validate parameters and data
+        self._validate_params()
+        y = check_y(y, self.link, self.distribution, verbose=self.verbose)
+        X = check_X(X, verbose=self.verbose)
+        check_X_y(X, y)
+
+        if weights is not None:
+            weights = np.array(weights).astype("f").ravel()
+            weights = check_array(
+                weights, name="sample weights", ndim=1, verbose=self.verbose
+            )
+            check_lengths(y, weights)
+        else:
+            weights = np.ones_like(y).astype("float64")
+
+        self._validate_data_dep_params(X)
+
+        # initialize logs/statistics
+        if not hasattr(self, "logs_"):
+            self.logs_ = defaultdict(list)
+        self.statistics_ = {}
+        self.statistics_["n_samples"] = len(y)
+        self.statistics_["m_features"] = X.shape[1]
+
+        rho = np.log(np.maximum(self._get_flat_lam(), EPS))
+        obj = self._objective_fn(X, y, weights, criterion=criterion, gamma=gamma)
+
+        best_rho = rho.copy()
+        best_val = obj(rho)
+
+        for _ in range(max_iter_outer):
+            val = obj(rho)
+            grad = smooth_opt.finite_difference_grad(obj, rho, eps=fd_eps)
+            hess = smooth_opt.finite_difference_hessian(obj, rho, eps=fd_eps)
+            step = smooth_opt.modified_newton_step(grad, hess)
+
+            # backtracking line search
+            alpha = 1.0
+            improved = False
+            while alpha > 1e-4:
+                trial_rho = rho + alpha * step
+                trial_val = obj(trial_rho)
+                if np.isfinite(trial_val) and trial_val < val:
+                    improved = True
+                    rho = trial_rho
+                    val = trial_val
+                    break
+                alpha *= 0.5
+
+            if val < best_val:
+                best_val = val
+                best_rho = rho.copy()
+
+            if np.linalg.norm(grad, ord=np.inf) < tol_outer:
+                break
+
+        # finalize at best rho found
+        self._set_flat_lam(np.exp(best_rho))
+        self._pirls(X, y, weights)
+        self.statistics_["lam_opt_result"] = {
+            "rho": best_rho,
+            "objective": criterion,
+            "value": best_val,
+        }
+        return self
+
     def _on_loop_start(self, variables):
         """
         Performs on-loop-start actions like callbacks.
@@ -857,7 +1060,17 @@ class GAM(Core, MetaTermMixin):
             if hasattr(callback, "on_loop_end"):
                 self.logs_[str(callback)].append(callback.on_loop_end(**variables))
 
-    def fit(self, X, y, weights=None):
+    def fit(
+        self,
+        X,
+        y,
+        weights=None,
+        lam_search=None,
+        lam_search_max_iter=20,
+        lam_search_tol=1e-3,
+        lam_search_bounds=(-20, 20),
+        lam_search_objective="auto",
+    ):
         """Fit the generalized additive model.
 
         Parameters
@@ -865,12 +1078,24 @@ class GAM(Core, MetaTermMixin):
         X : array-like, shape (n_samples, m_features)
             Training vectors.
         y : array-like, shape (n_samples, )
-            Target values,
-            (e.g. integers in classification, real numbers in
-            regression)
+        Target values,
+        (e.g. integers in classification, real numbers in
+        regression)
         weights : array-like shape (n_samples, ) or None, optional
             Sample weights.
             if None, defaults to array of ones
+        lam_search : {'outer', None, 'none'}, optional
+            When 'outer', estimate smoothing parameters via the Wood (2008)
+            outer-loop optimizer. Defaults to None (keep user-specified lambdas).
+        lam_search_max_iter : int, optional
+            Maximum number of iterations for the outer smoothing optimizer.
+        lam_search_tol : float, optional
+            Convergence tolerance passed to the outer optimizer.
+        lam_search_bounds : tuple or list of tuples, optional
+            Bounds (on log lambda) for the smoothing optimizer.
+        lam_search_objective : {'auto','GCV','UBRE'}, optional
+            Objective to minimize during smoothing selection. If 'auto', uses
+            UBRE when the scale parameter is known and GCV otherwise.
 
         Returns
         -------
@@ -907,7 +1132,22 @@ class GAM(Core, MetaTermMixin):
         self.statistics_["m_features"] = X.shape[1]
 
         # optimize
-        self._pirls(X, y, weights)
+        if lam_search in ("outer", True):
+            self._outer_lam_search(
+                X,
+                y,
+                weights,
+                objective=lam_search_objective,
+                max_iter=lam_search_max_iter,
+                tol=lam_search_tol,
+                bounds=lam_search_bounds,
+            )
+        elif lam_search in (None, "none", False):
+            self._pirls(X, y, weights)
+        else:
+            raise ValueError(
+                "lam_search must be one of {'outer', None, 'none', False, True}"
+            )
         # if self._opt == 0:
         #     self._pirls(X, y, weights)
         # if self._opt == 1:
@@ -1055,6 +1295,7 @@ class GAM(Core, MetaTermMixin):
             y=y, mu=mu, weights=weights
         ).sum()
         self.statistics_["p_values"] = self._estimate_p_values()
+        self.statistics_["lam"] = self._get_flat_lam()
 
     def _estimate_AIC(self, y, mu, weights=None):
         """
@@ -2889,7 +3130,7 @@ class PoissonGAM(GAM):
 
         return y, weights
 
-    def fit(self, X, y, exposure=None, weights=None):
+    def fit(self, X, y, exposure=None, weights=None, **kwargs):
         """Fit the generalized additive model.
 
         Parameters
@@ -2917,7 +3158,12 @@ class PoissonGAM(GAM):
             Returns fitted GAM object
         """
         y, weights = self._exposure_to_weights(y, exposure, weights)
-        return super(PoissonGAM, self).fit(X, y, weights)
+        return super(PoissonGAM, self).fit(
+            X,
+            y,
+            weights=weights,
+            **kwargs,
+        )
 
     def predict(self, X, exposure=None):
         """

--- a/pygam/smooth_optimizer.py
+++ b/pygam/smooth_optimizer.py
@@ -1,0 +1,136 @@
+"""
+Utilities for smoothness selection via outer-loop optimization.
+
+These helpers keep the implementation modular and allow derivative-based or
+finite-difference-based optimization around the existing PIRLS routine.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import scipy.linalg
+
+
+def estimate_rank(R, tol_cond=1e12):
+    """
+    Estimate effective rank by scanning leading principal minors of R.
+
+    Parameters
+    ----------
+    R : np.ndarray, upper triangular from QR
+    tol_cond : float
+        maximum allowed condition number
+    """
+    n = R.shape[0]
+    for r in range(n, 0, -1):
+        sub = R[:r, :r]
+        if np.linalg.cond(sub) < tol_cond:
+            return r
+    return 1
+
+
+def qr_decomp(WX, E, tol_cond=1e12):
+    """
+    Pivoted QR decomposition of [WX; E] per Wood (2008) Sec 3.2.
+
+    Parameters
+    ----------
+    WX : array (n, q) weighted model matrix
+    E : array (p, q) such that E.T @ E = S
+    tol_cond : float, condition number threshold for rank detection
+    """
+    aug = np.vstack([WX, E])
+    n, q = WX.shape
+    Q, R, piv = scipy.linalg.qr(aug, pivoting=True, mode="economic")
+    r = estimate_rank(R, tol_cond=tol_cond)
+    Qr = Q[:, :r]
+    Rr = R[:r, :r]
+    K = Qr[:n, :]
+    Rinv = scipy.linalg.solve_triangular(Rr, np.eye(r))
+    P = np.zeros((q, r))
+    P[piv[:r], :] = Rinv.T
+    return K, P, r
+
+
+def modified_newton_step(grad, hess):
+    """
+    Compute a safeguarded Newton step using |Lambda| eigenvalues.
+    """
+    # small ridge for numerical stability
+    eps = 1e-8
+    hess = hess + eps * np.eye(len(grad))
+    Xi, lam, _ = np.linalg.svd(hess)
+    H_mod = Xi @ np.diag(np.abs(lam)) @ Xi.T
+    return -np.linalg.solve(H_mod + eps * np.eye(len(grad)), grad)
+
+
+def finite_difference_grad(func, rho, eps=1e-4):
+    """Central finite-difference gradient of scalar func at rho."""
+    rho = np.asarray(rho, dtype=float)
+    grad = np.zeros_like(rho)
+    for i in range(len(rho)):
+        e = np.zeros_like(rho)
+        e[i] = eps
+        grad[i] = (func(rho + e) - func(rho - e)) / (2 * eps)
+    return grad
+
+
+def finite_difference_hessian(func, rho, eps=1e-4):
+    """Central finite-difference Hessian of scalar func at rho."""
+    rho = np.asarray(rho, dtype=float)
+    k = len(rho)
+    hess = np.zeros((k, k))
+    for i in range(k):
+        for j in range(k):
+            ei = np.zeros_like(rho)
+            ej = np.zeros_like(rho)
+            ei[i] = eps
+            ej[j] = eps
+            fpp = func(rho + ei + ej)
+            fpm = func(rho + ei - ej)
+            fmp = func(rho - ei + ej)
+            fmm = func(rho - ei - ej)
+            hess[i, j] = (fpp - fpm - fmp + fmm) / (4 * eps * eps)
+    return hess
+
+
+def compute_dtrA(trA_fn, rho, eps=1e-4):
+    """Finite-difference derivative of trace(A) given callable trA_fn(rho)."""
+    return finite_difference_grad(trA_fn, rho, eps=eps)
+
+
+def compute_d2trA(trA_fn, rho, eps=1e-4):
+    """Finite-difference Hessian of trace(A)."""
+    return finite_difference_hessian(trA_fn, rho, eps=eps)
+
+
+def compute_dbeta(beta_fn, rho, eps=1e-4):
+    """Finite-difference derivative of beta_hat wrt rho. beta_fn -> beta vector."""
+    rho = np.asarray(rho, dtype=float)
+    base = beta_fn(rho)
+    deriv = np.zeros((base.size, rho.size))
+    for i in range(rho.size):
+        e = np.zeros_like(rho)
+        e[i] = eps
+        deriv[:, i] = (beta_fn(rho + e) - beta_fn(rho - e)) / (2 * eps)
+    return deriv
+
+
+def compute_d2beta(beta_fn, rho, eps=1e-4):
+    """Finite-difference second derivative tensor of beta_hat wrt rho."""
+    rho = np.asarray(rho, dtype=float)
+    k = rho.size
+    base = beta_fn(rho)
+    second = np.zeros((base.size, k, k))
+    for i in range(k):
+        for j in range(k):
+            ei = np.zeros_like(rho)
+            ej = np.zeros_like(rho)
+            ei[i] = eps
+            ej[j] = eps
+            fpp = beta_fn(rho + ei + ej)
+            fpm = beta_fn(rho + ei - ej)
+            fmp = beta_fn(rho - ei + ej)
+            fmm = beta_fn(rho - ei - ej)
+            second[:, i, j] = (fpp - fpm - fmp + fmm) / (4 * eps * eps)
+    return second

--- a/pygam/tests/test_GAM_methods.py
+++ b/pygam/tests/test_GAM_methods.py
@@ -281,6 +281,14 @@ def test_get_params():
     params = gam.get_params()
     assert params["lam"] == 420
 
+def test_get_params_deep_true_returns_copy():
+    gam = LinearGAM()
+    original_max_iter = gam.max_iter
+
+    params = gam.get_params(deep=True)
+    params["max_iter"] = 1
+
+    assert gam.max_iter == original_max_iter
 
 class TestSamplingFromPosterior:
     def test_drawing_samples_from_unfitted_model(self, mcycle_X_y, mcycle_gam):

--- a/pygam/tests/test_core.py
+++ b/pygam/tests/test_core.py
@@ -30,3 +30,34 @@ def test_nice_repr_more_attrs():
     param_kvs = {"color": "blue", "n_ears": 3, "height": 1.3336}
     out = nice_repr("hi", param_kvs, line_width=60, line_offset=5, decimals=3)
     assert out == "hi(color='blue', height=1.334, n_ears=3)"
+
+
+def test_get_params_deep_true_returns_copy():
+    c = Core(name="cat", line_width=70, line_offset=3)
+    params = c.get_params(deep=True)
+
+    assert params is not c.__dict__
+    params["_name"] = "dog"
+    assert c._name == "cat"
+
+
+def test_get_params_default_does_not_mutate_dict_with_include():
+    class DemoCore(Core):
+        def __init__(self):
+            self.foo = 1
+            self._include = ["bar"]
+            super().__init__()
+
+        @property
+        def bar(self):
+            return 2
+
+    c = DemoCore()
+    assert "bar" not in c.__dict__
+
+    params = c.get_params()
+
+    assert params["foo"] == 1
+    assert params["bar"] == 2
+    assert "bar" not in c.__dict__
+

--- a/pygam/tests/test_outer_lambda.py
+++ b/pygam/tests/test_outer_lambda.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+from pygam import LinearGAM, PoissonGAM
+
+
+def test_outer_lambda_improves_gcv(mcycle_X_y):
+    X, y = mcycle_X_y
+
+    # start from a deliberately bad smoothing level
+    base = LinearGAM(lam=100.0, max_iter=50, tol=1e-3).fit(X, y)
+    base_score = base.statistics_["GCV"]
+
+    tuned = LinearGAM(lam=100.0, max_iter=50, tol=1e-3).fit(
+        X,
+        y,
+        lam_search="outer",
+        lam_search_max_iter=8,
+        lam_search_tol=1e-4,
+        lam_search_objective="GCV",
+    )
+
+    assert tuned.statistics_["lam_opt_result"] is not None
+    assert tuned.statistics_["lam_opt_result"].success
+    assert tuned.statistics_["GCV"] <= base_score * 1.01
+
+
+def test_outer_lambda_known_scale_uses_ubre(faithful_X_y):
+    X, y = faithful_X_y
+
+    gam = PoissonGAM(lam=5.0, max_iter=50, tol=1e-3).fit(
+        X,
+        y,
+        lam_search="outer",
+        lam_search_max_iter=6,
+        lam_search_objective="UBRE",
+    )
+
+    res = gam.statistics_.get("lam_opt_result")
+    assert res is not None
+    assert res.success or res.nit > 0
+    assert gam.statistics_["UBRE"] is not None
+    assert np.all(np.asarray(gam.statistics_["lam"]) > 0)

--- a/pygam/tests/test_smooth_optimizer.py
+++ b/pygam/tests/test_smooth_optimizer.py
@@ -1,0 +1,95 @@
+import numpy as np
+
+from pygam import LinearGAM, LogisticGAM, PoissonGAM, s
+from pygam.distributions import BinomialDist, GammaDist, PoissonDist
+from pygam.links import LogLink, LogitLink
+from pygam.smooth_optimizer import (
+    compute_dtrA,
+    compute_d2trA,
+    finite_difference_grad,
+    finite_difference_hessian,
+    modified_newton_step,
+    qr_decomp,
+)
+
+
+def test_distribution_v_prime():
+    for Dist in [PoissonDist, BinomialDist, GammaDist]:
+        dist = Dist()
+        mu = np.linspace(0.1, 0.9, 10)
+        analytical = dist.V_prime(mu)
+        numerical = (dist.V(mu + 1e-5) - dist.V(mu - 1e-5)) / (2e-5)
+        np.testing.assert_allclose(analytical, numerical, rtol=1e-4, atol=1e-6)
+
+
+def test_link_g_double_prime():
+    for Link in [LogLink, LogitLink]:
+        link = Link()
+        mu = np.linspace(0.1, 0.9, 10)
+        analytical = link.g_double_prime(mu, getattr(link, "dist", None) or BinomialDist())
+        numerical = (
+            link.link(mu + 1e-5, getattr(link, "dist", None) or BinomialDist())
+            - 2 * link.link(mu, getattr(link, "dist", None) or BinomialDist())
+            + link.link(mu - 1e-5, getattr(link, "dist", None) or BinomialDist())
+        ) / (1e-10)
+        np.testing.assert_allclose(analytical, numerical, rtol=1e-3, atol=1e-5)
+
+
+def test_qr_consistency():
+    rng = np.random.default_rng(42)
+    n, q = 60, 6
+    X = rng.standard_normal((n, q))
+    W = np.abs(rng.standard_normal(n)) + 0.1
+    S = np.eye(q) * 0.5
+    eigvals, eigvecs = np.linalg.eigh(S)
+    E = (eigvecs * np.sqrt(np.maximum(eigvals, 0))).T
+    K, P, r = qr_decomp(W[:, None] * X, E)
+    G = X.T @ np.diag(W**2) @ X + S
+    G_inv = np.linalg.inv(G)
+    PPt = P @ P.T
+    np.testing.assert_allclose(G_inv, PPt, rtol=1e-1, atol=1e-2)
+    assert r == q
+
+
+def test_finite_difference_helpers():
+    f = lambda r: np.sum(r**2)
+    rho = np.array([0.1, -0.2])
+    g = finite_difference_grad(f, rho, eps=1e-5)
+    h = finite_difference_hessian(f, rho, eps=1e-5)
+    np.testing.assert_allclose(g, 2 * rho, rtol=1e-4)
+    np.testing.assert_allclose(h, np.eye(2) * 2, rtol=1e-3)
+    step = modified_newton_step(g, h)
+    np.testing.assert_allclose(step, -rho, rtol=1e-3)
+
+
+def test_auto_smooth_gaussian():
+    rng = np.random.default_rng(0)
+    X = rng.uniform(0, 1, (120, 1))
+    y = np.sin(2 * np.pi * X[:, 0]) + rng.normal(scale=0.3, size=120)
+    gam_grid = LinearGAM(s(0)).gridsearch(X, y, lam=np.logspace(-2, 2, 5))
+    gam_auto = LinearGAM(s(0)).fit_auto_smooth(X, y, criterion="gcv", max_iter_outer=6)
+    gcv_grid = gam_grid.statistics_["GCV"]
+    gcv_auto = gam_auto.statistics_["GCV"]
+    assert gcv_auto <= gcv_grid * 1.1
+
+
+def test_auto_smooth_poisson():
+    rng = np.random.default_rng(1)
+    X = rng.uniform(0, 1, (150, 1))
+    y = rng.poisson(np.exp(np.sin(2 * np.pi * X[:, 0])) * 2.0)
+    gam = PoissonGAM(s(0)).fit_auto_smooth(X, y, criterion="aic", max_iter_outer=6)
+    assert gam.statistics_["AIC"] is not None
+    assert np.all(np.asarray(gam.statistics_["lam"]) > 0)
+
+
+def test_auto_smooth_logistic_concurvity():
+    rng = np.random.default_rng(2)
+    n = 200
+    x = rng.uniform(size=n)
+    d = x**3 + rng.normal(scale=0.01, size=n)
+    f_true = (d - 0.5 + 10 * (d - 0.5) ** 3) * 5
+    prob = 1 / (1 + np.exp(-f_true))
+    y = rng.binomial(1, prob)
+    X = np.column_stack([x, d])
+    gam = LogisticGAM(s(0) + s(1)).fit_auto_smooth(X, y, criterion="aic", max_iter_outer=5)
+    assert gam._is_fitted


### PR DESCRIPTION

I have implemented the following changes after referring the document provided in the issue : 
- I have added higher-order variance and link derviatives to distributions and link functions in order to support smoothness derivative calculations.
- I have made a new file named pygam/smoother_optimizer.py with QR/rank utilites, finite difference gradient/Hessian helpers and a safeguarded modified-Newton step function.
- I have also implemented fit_auto_smooth in GAM for Wood-2008 style outer-loop smoothing selection around the existing PIRLS inner loop which included dense penalty helper and objective wrapper.
- I have kept backward compatibility while storing optimization metadata (lam_opt_result, tuned λ) and wiring lambda handling utilities.
-Finally I  added comprehensive tests for derivative correctness, QR sanity, finite-difference helpers, and auto-smoothing on Gaussian, Poisson, and logistic concurvity scenarios.

** Solves issue ** #192 

**Tests** : There are two tests included in 
-  pygam/tests/test_outer_lambda.py (outer-loop λ search coverage)
-  pygam/tests/test_smooth_optimizer.py (derivative helpers and auto-smoothing integration)
Below is the result showing their successful passing : 
<img width="857" height="162" alt="image" src="https://github.com/user-attachments/assets/d3c8d16c-7511-4ab0-80c6-660b3b10287d" />

<img width="930" height="188" alt="image" src="https://github.com/user-attachments/assets/d363510a-60e1-4923-ad21-345a33207fbb" />
