### PR TITLE
fix(distributions): correct NormalDist weight handling and UBRE calculation

### DIFF
--- a/gen_imgs.py
+++ b/gen_imgs.py
@@ -1,5 +1,9 @@
 """Generate some plots for the pyGAM repo."""
 
+import matplotlib
+
+matplotlib.use("Agg")
+
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.font_manager import FontProperties
@@ -323,7 +327,6 @@ def chicago_tensor():
 
 
 def expectiles():
-
     """Generate expectiles visualization."""
     X, y = mcycle(return_X_y=True)
 

--- a/pygam/distributions.py
+++ b/pygam/distributions.py
@@ -127,7 +127,7 @@ class NormalDist(Distribution):
         """
         if weights is None:
             weights = np.ones_like(mu)
-        scale = self.scale / weights
+        scale = self.scale / np.sqrt(weights)
         return sp.stats.norm.logpdf(y, loc=mu, scale=scale)
 
     @divide_weights

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -1194,8 +1194,7 @@ class GAM(Core, MetaTermMixin):
         """
         if gamma < 1:
             raise ValueError(
-                "gamma scaling should be greater than 1, but found gamma = {}",
-                format(gamma),
+                f"gamma scaling should be greater than 1, but found gamma = {gamma}"
             )
 
         if modelmat is None:
@@ -1220,7 +1219,9 @@ class GAM(Core, MetaTermMixin):
             # scale is known, use UBRE
             scale = self.distribution.scale
             UBRE = (
-                1.0 / n * dev - (~add_scale) * (scale) + 2.0 * gamma / n * edof * scale
+                1.0 / n * dev
+                - float(not add_scale) * scale
+                + 2.0 * gamma / n * edof * scale
             )
         else:
             # scale unknown, use GCV

--- a/pygam/tests/test_distributions.py
+++ b/pygam/tests/test_distributions.py
@@ -1,0 +1,77 @@
+"""Tests for distribution classes, with focus on weight handling correctness."""
+
+import numpy as np
+import pytest
+from scipy.stats import norm
+
+from pygam.distributions import NormalDist
+
+
+class TestNormalDistLogPdf:
+    """Verify that NormalDist.log_pdf matches the GLM convention Var = σ²/w."""
+
+    def test_weighted_logpdf_matches_scipy(self):
+        """Weighted log-pdf should agree with scipy.stats.norm.logpdf
+        using sd = scale / sqrt(weights)."""
+        y = np.array([1.0, 2.0, 3.0])
+        mu = np.array([1.1, 1.9, 3.2])
+        weights = np.array([1.0, 2.0, 0.5])
+
+        dist = NormalDist(scale=1.0)
+
+        pygam_val = dist.log_pdf(y, mu, weights)
+        scipy_val = norm.logpdf(y, loc=mu, scale=1.0 / np.sqrt(weights))
+
+        np.testing.assert_allclose(pygam_val, scipy_val)
+
+    def test_unit_weights_match_unweighted(self):
+        """Unit weights should produce the same result as no weights."""
+        y = np.array([0.5, 1.5, 2.5])
+        mu = np.array([0.4, 1.6, 2.4])
+
+        dist = NormalDist(scale=1.0)
+
+        val_none = dist.log_pdf(y, mu, weights=None)
+        val_ones = dist.log_pdf(y, mu, weights=np.ones(3))
+
+        np.testing.assert_allclose(val_none, val_ones)
+
+    def test_scalar_weight(self):
+        """A scalar weight should broadcast correctly."""
+        y = np.array([1.0, 2.0])
+        mu = np.array([1.0, 2.0])
+
+        dist = NormalDist(scale=1.0)
+
+        # With weight=1 and y==mu, log_pdf should equal log(1/sqrt(2*pi))
+        val = dist.log_pdf(y, mu, weights=np.array([1.0, 1.0]))
+        expected = norm.logpdf(0.0, 0.0, 1.0)  # -0.9189...
+        np.testing.assert_allclose(val, expected)
+
+    def test_high_weight_concentrates_density(self):
+        """Higher weight should yield higher log-pdf at the mean
+        (narrower distribution)."""
+        y = np.array([1.0])
+        mu = np.array([1.0])
+
+        dist = NormalDist(scale=1.0)
+
+        lp_low = dist.log_pdf(y, mu, weights=np.array([1.0]))
+        lp_high = dist.log_pdf(y, mu, weights=np.array([100.0]))
+
+        # Higher weight → smaller sd → higher density at the mode
+        assert lp_high > lp_low
+
+    def test_nonunit_scale(self):
+        """Non-unit scale should be handled correctly with weights."""
+        y = np.array([2.0, 4.0])
+        mu = np.array([2.1, 3.8])
+        weights = np.array([1.0, 3.0])
+        scale = 2.5
+
+        dist = NormalDist(scale=scale)
+
+        pygam_val = dist.log_pdf(y, mu, weights)
+        scipy_val = norm.logpdf(y, loc=mu, scale=scale / np.sqrt(weights))
+
+        np.testing.assert_allclose(pygam_val, scipy_val)

--- a/pygam/tests/test_distributions.py
+++ b/pygam/tests/test_distributions.py
@@ -1,7 +1,6 @@
 """Tests for distribution classes, with focus on weight handling correctness."""
 
 import numpy as np
-import pytest
 from scipy.stats import norm
 
 from pygam.distributions import NormalDist


### PR DESCRIPTION
This PR fixes statistical correctness issues in the weighted log-likelihood computation for NormalDist and related UBRE calculations. Previously, weights were applied as scale = self.scale / weights, which implied a variance of σ²/w². Following the GLM convention used in PyGAM (Var = σ²/w), the correct standard deviation for weighted observations is σ/√w; therefore, the implementation has been updated to self.scale / np.sqrt(weights). Additionally, this PR corrects a boolean inversion bug in the UBRE computation (~add_scale → float(not add_scale)) and fixes a formatting issue in the gamma scaling ValueError message. Regression tests were added to validate weighted log-likelihood behavior against scipy.stats.norm.logpdf. All tests pass successfully. Fixes #457.