### PR TITLE
fix: link gridsearch progress bar to verbose parameter (#270)

### DIFF
--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -2043,7 +2043,7 @@ class GAM(Core, MetaTermMixin):
 
             def pbar(x):
                 return x
-            
+
         # loop through candidate model params
         for param_grid in pbar(param_grid_list):
             try:

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -1813,7 +1813,7 @@ class GAM(Core, MetaTermMixin):
         return_scores=False,
         keep_best=True,
         objective="auto",
-        progress=True,
+        progress=None,
         **param_grids,
     ):
         """
@@ -1857,9 +1857,10 @@ class GAM(Core, MetaTermMixin):
             If `auto`, then grid search will optimize `GCV` for models with unknown
             scale and `UBRE` for models with known scale.
 
-        progress : bool, optional
-            whether to display a progress bar
-
+        progress : bool or None, optional
+            whether to display a progress bar during gridsearch.
+            If None, defaults to self.verbose.
+            Default: None
         **kwargs
             pairs of parameters and iterables of floats, or
             parameters and iterables of iterables of floats.
@@ -2030,14 +2031,17 @@ class GAM(Core, MetaTermMixin):
             best_model = models[-1]
             best_score = scores[-1]
 
+        # AFTER
         # make progressbar optional
+        # if progress is None, fall back to self.verbose
+        if progress is None:
+            progress = self.verbose
+
         if progress:
             pbar = ProgressBar()
         else:
-
             def pbar(x):
                 return x
-
         # loop through candidate model params
         for param_grid in pbar(param_grid_list):
             try:

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -2040,8 +2040,10 @@ class GAM(Core, MetaTermMixin):
         if progress:
             pbar = ProgressBar()
         else:
+
             def pbar(x):
                 return x
+            
         # loop through candidate model params
         for param_grid in pbar(param_grid_list):
             try:


### PR DESCRIPTION
## Summary
Fixes #270

## Problem
The `gridsearch()` function had a `progress=True` parameter that was 
hardcoded and not connected to the model's `verbose` setting.
This meant the progress bar always showed regardless of `verbose=False`.

## Fix
- Changed `progress` default from `True` to `None`
- When `progress=None`, it now falls back to `self.verbose`
- This way `verbose=False` automatically suppresses the progress bar
- Users can still override explicitly with `progress=True/False`

## Testing
Tested 3 scenarios:
- `verbose=False` → no progress bar shown ✅
- `verbose=True` → progress bar shown ✅  
- `progress=False` explicitly → no progress bar shown ✅