### PR TITLE
Fix #545: Resolve empty Effective DoF in summary() for overparameterized models

### DIFF
--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -1030,7 +1030,7 @@ class GAM(Core, MetaTermMixin):
         """
         lp = self._linear_predictor(modelmat=modelmat)
         mu = self.link.mu(lp, self.distribution)
-        self.statistics_["edof_per_coef"] = np.diagonal(U1.dot(U1.T))
+        self.statistics_["edof_per_coef"] = (U1**2).sum(axis=1)
         self.statistics_["edof"] = self.statistics_["edof_per_coef"].sum()
         if not self.distribution._known_scale:
             self.distribution.scale = (
@@ -1756,7 +1756,7 @@ class GAM(Core, MetaTermMixin):
                 idx = self.terms.get_coef_indices(i)
                 edof = np.round(self.statistics_["edof_per_coef"][idx].sum(), 1)
             else:
-                edof = ""
+                edof = float("nan")
 
             term_data = {
                 "feature_func": repr(term),
@@ -1804,6 +1804,14 @@ class GAM(Core, MetaTermMixin):
             "github.com/dswah/pyGAM/issues/163 \n",
             stacklevel=2,
         )
+
+        if len(self.statistics_["edof_per_coef"]) != len(self.coef_):
+            warnings.warn(
+                "Model is overparameterized (n_samples < n_coefs). "
+                "Effective degrees of freedom (EDoF) per term cannot be reliably computed "
+                "and are set to NaN.",
+                stacklevel=2,
+            )
 
     def gridsearch(
         self,

--- a/pygam/tests/test_GAM_methods.py
+++ b/pygam/tests/test_GAM_methods.py
@@ -104,7 +104,10 @@ def test_more_splines_than_samples(mcycle_X_y):
     # we cannot display the term-by-term effective DoF because we have fewer
     # values than coefficients
     assert len(gam.statistics_["edof_per_coef"]) < len(gam.coef_)
-    gam.summary()
+
+    # Our bug fix issues a warning that the model is overparameterized and sets EDoF to NaN
+    with pytest.warns(UserWarning, match="Model is overparameterized"):
+        gam.summary()
 
 
 def test_deviance_residuals(mcycle_X_y, mcycle_gam):


### PR DESCRIPTION
Fixes #545 
## Description
This PR fixes the bug where the Effective Degrees of Freedom (EDoF) per term in `summary()` is printed as an empty string for overparameterized models (where the number of samples is less than the number of coefficients). 

## Changes Made
1. Modify `summary()` in `pygam.py` to correctly fall back to `float("nan")` instead of `""` for overparameterized models so the summary table is properly formatted.
2. 2. Add a `warnings.warn` specifically calling out that the model is overparameterized and the EDoF per term cannot be reliably computed.
3. 3. **Optimization/Vectorization**: Replaced `np.diagonal(U1.dot(U1.T))` with `(U1**2).sum(axis=1)` to avoid calculating a full dense matrix just to slice the diagonal, improving efficiency while maintaining identical results. 
4. 4. Updated test assertions in `tests/test_GAM_methods.py` to capture this warning properly.
All existing tests pass correctly.