### PR TITLE
enh: allow summary to return string (fixes #316)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,5 +125,7 @@ jobs:
       run: uv pip list
 
     - name: Test with pytest
+      env:
+        MPLBACKEND: Agg
       run: |
         pytest --cov=pygam

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -700,9 +700,9 @@ class GAM(Core, MetaTermMixin):
 
         y_ = self.link.link(y, self.distribution)
         y_ = make_2d(y_, verbose=False)
-        assert np.isfinite(
-            y_
-        ).all(), "transformed response values should be well-behaved."
+        assert np.isfinite(y_).all(), (
+            "transformed response values should be well-behaved."
+        )
 
         # solve the linear problem
         return np.linalg.solve(
@@ -741,9 +741,9 @@ class GAM(Core, MetaTermMixin):
             # initialize the model
             self.coef_ = self._initial_estimate(Y, modelmat)
 
-        assert np.isfinite(
-            self.coef_
-        ).all(), f"coefficients should be well-behaved, but found: {self.coef_}"
+        assert np.isfinite(self.coef_).all(), (
+            f"coefficients should be well-behaved, but found: {self.coef_}"
+        )
 
         P = self._P()
         S = sp.sparse.diags(np.ones(m) * np.sqrt(EPS))  # improve condition
@@ -1041,8 +1041,8 @@ class GAM(Core, MetaTermMixin):
             )
         self.statistics_["scale"] = self.distribution.scale
         self.statistics_["cov"] = (
-            B.dot(B.T)
-        ) * self.distribution.scale**2  # parameter covariances. no need to remove a W because we are using W^2. Wood pg 184  # noqa: E501
+            (B.dot(B.T)) * self.distribution.scale** 2
+        )  # parameter covariances. no need to remove a W because we are using W^2. Wood pg 184  # noqa: E501
         self.statistics_["se"] = self.statistics_["cov"].diagonal() ** 0.5
         self.statistics_["AIC"] = self._estimate_AIC(y=y, mu=mu, weights=weights)
         self.statistics_["AICc"] = self._estimate_AICc(y=y, mu=mu, weights=weights)

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -700,9 +700,9 @@ class GAM(Core, MetaTermMixin):
 
         y_ = self.link.link(y, self.distribution)
         y_ = make_2d(y_, verbose=False)
-        assert np.isfinite(y_).all(), (
-            "transformed response values should be well-behaved."
-        )
+        assert np.isfinite(
+            y_
+        ).all(), "transformed response values should be well-behaved."
 
         # solve the linear problem
         return np.linalg.solve(
@@ -741,9 +741,9 @@ class GAM(Core, MetaTermMixin):
             # initialize the model
             self.coef_ = self._initial_estimate(Y, modelmat)
 
-        assert np.isfinite(self.coef_).all(), (
-            f"coefficients should be well-behaved, but found: {self.coef_}"
-        )
+        assert np.isfinite(
+            self.coef_
+        ).all(), f"coefficients should be well-behaved, but found: {self.coef_}"
 
         P = self._P()
         S = sp.sparse.diags(np.ones(m) * np.sqrt(EPS))  # improve condition
@@ -1041,8 +1041,8 @@ class GAM(Core, MetaTermMixin):
             )
         self.statistics_["scale"] = self.distribution.scale
         self.statistics_["cov"] = (
-            (B.dot(B.T)) * self.distribution.scale** 2
-        )  # parameter covariances. no need to remove a W because we are using W^2. Wood pg 184  # noqa: E501
+            B.dot(B.T)
+        ) * self.distribution.scale**2  # parameter covariances. no need to remove a W because we are using W^2. Wood pg 184  # noqa: E501
         self.statistics_["se"] = self.statistics_["cov"].diagonal() ** 0.5
         self.statistics_["AIC"] = self._estimate_AIC(y=y, mu=mu, weights=weights)
         self.statistics_["AICc"] = self._estimate_AICc(y=y, mu=mu, weights=weights)
@@ -1789,7 +1789,9 @@ class GAM(Core, MetaTermMixin):
         res.append("=" * 106)
         res.append(TablePrinter(fmt, ul="=")(data))
         res.append("=" * 106)
-        res.append("Significance codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1")
+        res.append(
+            "Significance codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1"
+        )
         res.append("")
         res.append(
             "WARNING: Fitting splines and a linear function to a feature introduces a model identifiability problem\n"
@@ -1801,7 +1803,7 @@ class GAM(Core, MetaTermMixin):
             "         known smoothing parameters, but when smoothing parameters have been estimated, the p-values\n"
             "         are typically lower than they should be, meaning that the tests reject the null too readily."
         )
-        
+
         res_str = "\n".join(res)
 
         # P-VALUE BUG

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -1642,12 +1642,18 @@ class GAM(Core, MetaTermMixin):
 
         return out[0]
 
-    def summary(self):
+    def summary(self, return_str=False):
         """Produce a summary of the model statistics.
+
+        Parameters
+        ----------
+        return_str : bool, optional
+            Whether to return the summary as a string instead of printing to stdout.
 
         Returns
         -------
-        None
+        None or str
+            Summary of the model if return_str is True, else None.
         """
         if not self._is_fitted:
             raise AttributeError("GAM has not been fitted. Call fit first.")
@@ -1778,22 +1784,25 @@ class GAM(Core, MetaTermMixin):
             ("Sig. Code", "sig_code", 12),
         ]
 
-        print(TablePrinter(model_fmt, ul="=", sep=" ")(model_details))
-        print("=" * 106)
-        print(TablePrinter(fmt, ul="=")(data))
-        print("=" * 106)
-        print("Significance codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1")
-        print()
-        print(
-            "WARNING: Fitting splines and a linear function to a feature introduces a model identifiability problem\n"  # noqa: E501
+        res = []
+        res.append(TablePrinter(model_fmt, ul="=", sep=" ")(model_details))
+        res.append("=" * 106)
+        res.append(TablePrinter(fmt, ul="=")(data))
+        res.append("=" * 106)
+        res.append("Significance codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1")
+        res.append("")
+        res.append(
+            "WARNING: Fitting splines and a linear function to a feature introduces a model identifiability problem\n"
             "         which can cause p-values to appear significant when they are not."
         )
-        print()
-        print(
-            "WARNING: p-values calculated in this manner behave correctly for un-penalized models or models with\n"  # noqa: E501
-            "         known smoothing parameters, but when smoothing parameters have been estimated, the p-values\n"  # noqa: E501
-            "         are typically lower than they should be, meaning that the tests reject the null too readily."  # noqa: E501
+        res.append("")
+        res.append(
+            "WARNING: p-values calculated in this manner behave correctly for un-penalized models or models with\n"
+            "         known smoothing parameters, but when smoothing parameters have been estimated, the p-values\n"
+            "         are typically lower than they should be, meaning that the tests reject the null too readily."
         )
+        
+        res_str = "\n".join(res)
 
         # P-VALUE BUG
         warnings.warn(
@@ -1804,6 +1813,11 @@ class GAM(Core, MetaTermMixin):
             "github.com/dswah/pyGAM/issues/163 \n",
             stacklevel=2,
         )
+
+        if return_str:
+            return res_str
+        else:
+            print(res_str)
 
     def gridsearch(
         self,


### PR DESCRIPTION
This PR fixes issue #316 by adding a `return_str` flag to the `GAM.summary()` method.\n\nNow, users can do:\n```python\nmodel_summary = gam.summary(return_str=True)\n```\nto easily save the tabular output to a variable, or write it to a file, instead of having it strictly routed to stdout.