### PR TITLE
Add confidence interval visualization to regression exampleLinear Regression example added

### DIFF
--- a/examples/gam_regression.py
+++ b/examples/gam_regression.py
@@ -1,0 +1,55 @@
+"""
+Basic Regression Example using pyGAM
+
+This example demonstrates:
+1. Generating synthetic nonlinear data
+2. Training a GAM regression model
+3. Making predictions with confidence intervals
+4. Visualizing the results
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+from pygam import LinearGAM, s
+
+
+np.random.seed(0)
+
+X = np.linspace(0, 5, 100)
+y = np.sin(X) + np.random.normal(scale=0.2, size=100)
+
+
+X = X.reshape(-1, 1)
+
+
+gam = LinearGAM(s(0)).fit(X, y)
+
+
+X_pred = np.linspace(0, 5, 200).reshape(-1, 1)
+y_pred = gam.predict(X_pred)
+y_conf = gam.confidence_intervals(X_pred)
+
+
+#Visualize
+plt.figure(figsize=(8, 5))
+plt.scatter(X, y, label="Data", alpha=0.6)
+# GAM prediction line
+plt.plot(X_pred, y_pred, color="red", label="GAM Fit")
+
+# Confidence interval shading
+plt.fill_between(
+    X_pred.flatten(),
+    y_conf[:, 0],
+    y_conf[:, 1],
+    color="red",
+    alpha=0.2,
+    label="Confidence Interval"
+)
+
+# Labels and title
+plt.title("pyGAM Regression Example with Confidence Intervals")
+plt.xlabel("X")
+plt.ylabel("y")
+plt.legend()
+plt.tight_layout()
+plt.show()

--- a/examples/gam_regression.py
+++ b/examples/gam_regression.py
@@ -8,10 +8,10 @@ This example demonstrates:
 4. Visualizing the results
 """
 
-import numpy as np
 import matplotlib.pyplot as plt
-from pygam import LinearGAM, s
+import numpy as np
 
+from pygam import LinearGAM, s
 
 np.random.seed(0)
 

--- a/examples/gam_regression.py
+++ b/examples/gam_regression.py
@@ -30,7 +30,7 @@ y_pred = gam.predict(X_pred)
 y_conf = gam.confidence_intervals(X_pred)
 
 
-#Visualize
+# Visualize
 plt.figure(figsize=(8, 5))
 plt.scatter(X, y, label="Data", alpha=0.6)
 # GAM prediction line
@@ -43,7 +43,7 @@ plt.fill_between(
     y_conf[:, 1],
     color="red",
     alpha=0.2,
-    label="Confidence Interval"
+    label="Confidence Interval",
 )
 
 # Labels and title

--- a/gen_imgs.py
+++ b/gen_imgs.py
@@ -323,7 +323,6 @@ def chicago_tensor():
 
 
 def expectiles():
-
     """Generate expectiles visualization."""
     X, y = mcycle(return_X_y=True)
 


### PR DESCRIPTION
This PR enhances the basic regression example by adding confidence interval visualization using `confidence_intervals()`.

This helps users better understand model uncertainty and improves interpretability while keeping the example beginner-friendly.

No changes to existing functionality — only improves documentation/example clarity.