### PR TITLE
Improve p-value warning message and documentation (Wood 2013 reference) – relates to #163

### DIFF
--- a/gen_imgs.py
+++ b/gen_imgs.py
@@ -323,7 +323,6 @@ def chicago_tensor():
 
 
 def expectiles():
-
     """Generate expectiles visualization."""
     X, y = mcycle(return_X_y=True)
 

--- a/gen_imgs.py
+++ b/gen_imgs.py
@@ -1,5 +1,7 @@
 """Generate some plots for the pyGAM repo."""
+
 import matplotlib
+
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np

--- a/gen_imgs.py
+++ b/gen_imgs.py
@@ -1,5 +1,6 @@
 """Generate some plots for the pyGAM repo."""
-
+import matplotlib
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.font_manager import FontProperties

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -1797,9 +1797,9 @@ class GAM(Core, MetaTermMixin):
             "smaller than they should be. This implementation follows "
             "Wood (2006) which tends to reject the null hypothesis too "
             "easily when smoothing parameters are estimated.\n\n"
-            "A more reliable method is described in Wood (2013): "
+            "A more reliable method is described in Wood (2013):"
             "'On p-values for smooth components of an extended "
-            "generalized additive model', Biometrika 100(1):221–228.\n\n"
+            "generalized additive model', Biometrika 100(1):221-228.\n\n"
             "See https://github.com/dswah/pyGAM/issues/163 for discussion.",
             UserWarning,
             stacklevel=2,

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -1263,7 +1263,7 @@ class GAM(Core, MetaTermMixin):
         based on equations from Wood 2006 section 4.8.5 page 191
         and errata https://people.maths.bris.ac.uk/~sw15190/igam/iGAMerrata-12.pdf
     """
-        
+
         if not self._is_fitted:
             raise AttributeError("GAM has not been fitted. Call fit first.")
 

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -1262,8 +1262,7 @@ class GAM(Core, MetaTermMixin):
         generalized additive model", Biometrika 100(1):221–228.
         based on equations from Wood 2006 section 4.8.5 page 191
         and errata https://people.maths.bris.ac.uk/~sw15190/igam/iGAMerrata-12.pdf
-    """
-
+        """
         if not self._is_fitted:
             raise AttributeError("GAM has not been fitted. Call fit first.")
 
@@ -1792,7 +1791,6 @@ class GAM(Core, MetaTermMixin):
 
         # P-VALUE BUG
         warnings.warn(
-
             "KNOWN LIMITATION: p-values computed in this summary may be "
             "smaller than they should be. This implementation follows "
             "Wood (2006) which tends to reject the null hypothesis too "

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -1252,23 +1252,18 @@ class GAM(Core, MetaTermMixin):
 
         Notes
         -----
-        Wood 2006, section 4.8.5:
-            The p-values, calculated in this manner, behave correctly for un-penalized
-            models, or models with known smoothing parameters, but when smoothing
-            parameters have been estimated, the p-values are typically lower than they
-            should be, meaning that the tests reject the null too readily.
+        Current p-value computation follows Wood (2006) section 4.8.5.
+        This approach is known to underestimate p-values when smoothing
+        parameters are estimated.
 
-                (...)
-
-            In practical terms, if these p-values suggest that a term is not needed in
-            a model, then this is probably true, but if a term is deemed ‘significant’
-            it is important to be aware that this significance may be overstated.
-
+        A more reliable method using rank-r truncated eigendecomposition
+        is described in:
+        Wood (2014), "On p-values for smooth components of an extended
+        generalized additive model", Biometrika 100(1):221–228.
         based on equations from Wood 2006 section 4.8.5 page 191
         and errata https://people.maths.bris.ac.uk/~sw15190/igam/iGAMerrata-12.pdf
-
-        the errata show a correction for the f-statistic.
-        """
+    """
+        
         if not self._is_fitted:
             raise AttributeError("GAM has not been fitted. Call fit first.")
 
@@ -1797,11 +1792,16 @@ class GAM(Core, MetaTermMixin):
 
         # P-VALUE BUG
         warnings.warn(
-            "KNOWN BUG: p-values computed in this summary are likely "
-            "much smaller than they should be. \n \n"
-            "Please do not make inferences based on these values! \n\n"
-            "Collaborate on a solution, and stay up to date at: \n"
-            "github.com/dswah/pyGAM/issues/163 \n",
+
+            "KNOWN LIMITATION: p-values computed in this summary may be "
+            "smaller than they should be. This implementation follows "
+            "Wood (2006) which tends to reject the null hypothesis too "
+            "easily when smoothing parameters are estimated.\n\n"
+            "A more reliable method is described in Wood (2013): "
+            "'On p-values for smooth components of an extended "
+            "generalized additive model', Biometrika 100(1):221–228.\n\n"
+            "See https://github.com/dswah/pyGAM/issues/163 for discussion.",
+            UserWarning,
             stacklevel=2,
         )
 

--- a/the Wood (2006) one-step pinv formula with the corrected approach from Wood (2013b, Biometrika 100221-228)
+++ b/the Wood (2006) one-step pinv formula with the corrected approach from Wood (2013b, Biometrika 100221-228)
@@ -1,0 +1,60 @@
+[1mdiff --git a/pygam/pygam.py b/pygam/pygam.py[m
+[1mindex 6f86ae4..5c7db8d 100644[m
+[1m--- a/pygam/pygam.py[m
+[1m+++ b/pygam/pygam.py[m
+[36m@@ -1252,23 +1252,18 @@[m [mclass GAM(Core, MetaTermMixin):[m
+ [m
+         Notes[m
+         -----[m
+[31m-        Wood 2006, section 4.8.5:[m
+[31m-            The p-values, calculated in this manner, behave correctly for un-penalized[m
+[31m-            models, or models with known smoothing parameters, but when smoothing[m
+[31m-            parameters have been estimated, the p-values are typically lower than they[m
+[31m-            should be, meaning that the tests reject the null too readily.[m
+[31m-[m
+[31m-                (...)[m
+[31m-[m
+[31m-            In practical terms, if these p-values suggest that a term is not needed in[m
+[31m-            a model, then this is probably true, but if a term is deemed ‘significant’[m
+[31m-            it is important to be aware that this significance may be overstated.[m
+[31m-[m
+[32m+[m[32m        Current p-value computation follows Wood (2006) section 4.8.5.[m
+[32m+[m[32m        This approach is known to underestimate p-values when smoothing[m
+[32m+[m[32m        parameters are estimated.[m
+[32m+[m
+[32m+[m[32m        A more reliable method using rank-r truncated eigendecomposition[m
+[32m+[m[32m        is described in:[m
+[32m+[m[32m        Wood (2014), "On p-values for smooth components of an extended[m
+[32m+[m[32m        generalized additive model", Biometrika 100(1):221–228.[m
+         based on equations from Wood 2006 section 4.8.5 page 191[m
+         and errata https://people.maths.bris.ac.uk/~sw15190/igam/iGAMerrata-12.pdf[m
+[31m-[m
+[31m-        the errata show a correction for the f-statistic.[m
+[31m-        """[m
+[32m+[m[32m    """[m
+[32m+[m[41m        [m
+         if not self._is_fitted:[m
+             raise AttributeError("GAM has not been fitted. Call fit first.")[m
+ [m
+[36m@@ -1797,11 +1792,16 @@[m [mclass GAM(Core, MetaTermMixin):[m
+ [m
+         # P-VALUE BUG[m
+         warnings.warn([m
+[31m-            "KNOWN BUG: p-values computed in this summary are likely "[m
+[31m-            "much smaller than they should be. \n \n"[m
+[31m-            "Please do not make inferences based on these values! \n\n"[m
+[31m-            "Collaborate on a solution, and stay up to date at: \n"[m
+[31m-            "github.com/dswah/pyGAM/issues/163 \n",[m
+[32m+[m
+[32m+[m[32m            "KNOWN LIMITATION: p-values computed in this summary may be "[m
+[32m+[m[32m            "smaller than they should be. This implementation follows "[m
+[32m+[m[32m            "Wood (2006) which tends to reject the null hypothesis too "[m
+[32m+[m[32m            "easily when smoothing parameters are estimated.\n\n"[m
+[32m+[m[32m            "A more reliable method is described in Wood (2013): "[m
+[32m+[m[32m            "'On p-values for smooth components of an extended "[m
+[32m+[m[32m            "generalized additive model', Biometrika 100(1):221–228.\n\n"[m
+[32m+[m[32m            "See https://github.com/dswah/pyGAM/issues/163 for discussion.",[m
+[32m+[m[32m            UserWarning,[m
+             stacklevel=2,[m
+         )[m
+ [m


### PR DESCRIPTION

Summary

This PR improves the warning message related to p-value computation in summary() and clarifies the limitations of the current implementation.

The current implementation follows Wood (2006), which is known to produce p-values that may be smaller than they should be when smoothing parameters are estimated. This PR updates the warning message to make this limitation clearer and references the improved method described in Wood (2013).

No functional changes were made to the statistical computation itself — this change focuses only on improving clarity for users.

⸻

Changes
	•	Updated warning message from “KNOWN BUG” to “KNOWN LIMITATION”
	•	Added proper citation to Wood (2013), Biometrika 100(1):221–228
	•	Explicitly used UserWarning
	•	Updated _compute_p_value() docstring to reference Wood (2013) and explain the limitation of the current Wood (2006) approach

Testing

All tests pass after the change.

162 passed, 1 skipped

Since this PR only updates warnings and documentation, it does not affect model behavior or break existing functionality.

Example Warning

Before

KNOWN BUG: p-values computed in this summary are likely much smaller than they should be.

After

KNOWN LIMITATION: p-values computed in this summary may be smaller than they should be.


BEFORE TERMINAL OUTPUT:
<img width="1362" height="766" alt="image" src="https://github.com/user-attachments/assets/e214ed24-2a0f-4fe7-8cd5-a0d2dd095a03" />


AFTER TERMINAL OUTPUT:
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/0a82016c-47c8-465d-ab7c-1aa5baf7a8f7" />


This implementation follows Wood (2006) which tends to reject the null hypothesis too easily when smoothing parameters are estimated.

A more reliable method is described in:
Wood (2013), "On p-values for smooth components of an extended generalized additive model",
Biometrika 100(1):221–228.

Fixes #589 
