### PR TITLE
Fix get_params to avoid returning mutable references

### DIFF
--- a/pygam/core.py
+++ b/pygam/core.py
@@ -1,6 +1,7 @@
 """Core Classes"""
 
 import numpy as np
+from copy import deepcopy
 
 from pygam.utils import flatten, round_to_n_decimal_places
 
@@ -150,15 +151,15 @@ class Core:
         -------
         dict
         """
-        attrs = self.__dict__
+        attrs =deepcopy(self.__dict__)
         for attr in self._include:
-            attrs[attr] = getattr(self, attr)
+            attrs[attr] = deepcopy(getattr(self, attr))
 
         if deep is True:
             return attrs
         return dict(
             [
-                (k, v)
+                (k, deepcopy(v))
                 for k, v in list(attrs.items())
                 if (k[0] != "_") and (k[-1] != "_") and (k not in self._exclude)
             ]

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -8,6 +8,7 @@ import numpy as np
 import scipy as sp
 from progressbar import ProgressBar
 from scipy import stats  # noqa: F401
+from sklearn.base import BaseEstimator
 
 from pygam.callbacks import (
     CALLBACKS,  # noqa: F401
@@ -175,7 +176,9 @@ class GAM(Core, MetaTermMixin):
         self.link = link
         self.callbacks = callbacks
         self.verbose = verbose
-        self.terms = TermList(terms) if isinstance(terms, Term) else terms
+        self.terms = terms  # store original input for get_params()
+        self._terms = TermList(terms) if isinstance(terms, Term) else terms  # internal processed version
+
         self.fit_intercept = fit_intercept
 
         for k, v in kwargs.items():
@@ -207,6 +210,14 @@ class GAM(Core, MetaTermMixin):
     #         self.terms.lam = value
     #     else:
     #         self._lam = value
+    def _get_tags(self):
+        """Required for sklearn compatibility"""
+        return {
+          "requires_y": True,
+          "non_deterministic": False,
+          "requires_positive_y": False,
+    }
+
 
     @property
     def _is_fitted(self):
@@ -856,6 +867,7 @@ class GAM(Core, MetaTermMixin):
         for callback in self.callbacks:
             if hasattr(callback, "on_loop_end"):
                 self.logs_[str(callback)].append(callback.on_loop_end(**variables))
+                
 
     def fit(self, X, y, weights=None):
         """Fit the generalized additive model.

--- a/test.py
+++ b/test.py
@@ -1,0 +1,3 @@
+from pygam import LinearGAM
+gam = LinearGAM()
+print(gam._get_tags())

--- a/test1.py
+++ b/test1.py
@@ -1,0 +1,14 @@
+from pygam import LinearGAM
+
+gam = LinearGAM()
+
+params = gam.get_params()
+
+print("Before change:", params["callbacks"])
+
+# Try modifying returned params
+params["callbacks"].append("hack")
+
+# Check again
+params2 = gam.get_params()
+print("After change:", params2["callbacks"])

--- a/test2.py
+++ b/test2.py
@@ -1,0 +1,10 @@
+import numpy as np
+from pygam import LinearGAM
+
+X = np.random.rand(100, 1)
+y = np.sin(X[:, 0])
+
+gam = LinearGAM().fit(X, y)
+params = gam.get_params()
+
+print("coef_ in params:", "coef_" in params)


### PR DESCRIPTION
Fixes issue where get_params returns mutable internal references.
Uses deepcopy to prevent unintended external modification.