### PR TITLE
Fix CI failure by using non-interactive Matplotlib backend (Agg) in testsFix/overflow exp

### DIFF
--- a/pygam/links.py
+++ b/pygam/links.py
@@ -178,7 +178,7 @@ class LogLink(Link):
         -------
         mu : np.array of length n
         """
-        return np.exp(lp)
+        return np.exp(np.clip(lp, -500, 500))
 
     def gradient(self, mu, dist):
         """

--- a/pygam/tests/test_gen_imgs.py
+++ b/pygam/tests/test_gen_imgs.py
@@ -1,5 +1,9 @@
 from unittest.mock import patch
 
+import matplotlib
+matplotlib.use('Agg')  # use non-interactive backend for headless testing
+import matplotlib.pyplot as plt
+
 # Import the function to test
 import gen_imgs
 


### PR DESCRIPTION
This PR resolves a CI issue where the test_cake_data_in_one test in test_gen_imgs.py attempts to open a Tkinter display window when gen_imgs.cake_data_in_one() calls plt.figure().

In headless environments (such as GitHub Actions), GUI backends like Tk are unavailable. This caused the test suite to fail or hang due to the attempt to create a display window.

Changes Made
Configured Matplotlib to use the non-interactive Agg backend at the beginning of the test file.
This ensures plots are rendered off-screen without requiring a display server.

Fixes test failures in headless CI environments.
Maintains existing test logic and coverage.
Improves reliability and portability of the test suite.