### PR TITLE
Fix CI failure by using non-interactive Matplotlib backend (Agg) in tests

### DIFF
--- a/gen_imgs.py
+++ b/gen_imgs.py
@@ -323,7 +323,6 @@ def chicago_tensor():
 
 
 def expectiles():
-
     """Generate expectiles visualization."""
     X, y = mcycle(return_X_y=True)
 

--- a/pygam/tests/conftest.py
+++ b/pygam/tests/conftest.py
@@ -1,6 +1,3 @@
-import os
-os.environ["MPLBACKEND"] = "Agg"
-
 import pytest
 
 from pygam import (

--- a/pygam/tests/conftest.py
+++ b/pygam/tests/conftest.py
@@ -1,3 +1,6 @@
+import os
+os.environ["MPLBACKEND"] = "Agg"
+
 import pytest
 
 from pygam import (

--- a/pygam/tests/test_gen_imgs.py
+++ b/pygam/tests/test_gen_imgs.py
@@ -1,7 +1,15 @@
 from unittest.mock import patch
 
+import pytest
+
 # Import the function to test
 import gen_imgs
+
+
+@pytest.fixture(autouse=True)
+def mock_pyplot_windows():
+    with patch("gen_imgs.plt.figure"), patch("gen_imgs.plt.show"):
+        yield
 
 
 def test_gen_basis_fns():

--- a/pygam/tests/test_gen_imgs.py
+++ b/pygam/tests/test_gen_imgs.py
@@ -1,11 +1,17 @@
 from unittest.mock import patch
 
-import matplotlib
-
-matplotlib.use("Agg")  # use non-interactive backend for headless testing
+import pytest
 
 # Import the function to test
 import gen_imgs
+
+
+@pytest.fixture(autouse=True)
+def use_agg_backend():
+    import matplotlib
+
+    matplotlib.use("Agg")
+    yield
 
 
 def test_gen_basis_fns():

--- a/pygam/tests/test_gen_imgs.py
+++ b/pygam/tests/test_gen_imgs.py
@@ -1,5 +1,9 @@
 from unittest.mock import patch
 
+import matplotlib
+matplotlib.use('Agg')  # use non-interactive backend for headless testing
+import matplotlib.pyplot as plt
+
 # Import the function to test
 import gen_imgs
 

--- a/pygam/tests/test_gen_imgs.py
+++ b/pygam/tests/test_gen_imgs.py
@@ -1,17 +1,7 @@
 from unittest.mock import patch
 
-import pytest
-
 # Import the function to test
 import gen_imgs
-
-
-@pytest.fixture(autouse=True)
-def use_agg_backend():
-    import matplotlib
-
-    matplotlib.use("Agg")
-    yield
 
 
 def test_gen_basis_fns():

--- a/pygam/tests/test_gen_imgs.py
+++ b/pygam/tests/test_gen_imgs.py
@@ -1,8 +1,8 @@
 from unittest.mock import patch
 
 import matplotlib
-matplotlib.use('Agg')  # use non-interactive backend for headless testing
-import matplotlib.pyplot as plt
+
+matplotlib.use("Agg")  # use non-interactive backend for headless testing
 
 # Import the function to test
 import gen_imgs


### PR DESCRIPTION
This PR resolves a CI issue where the test_cake_data_in_one test in test_gen_imgs.py attempts to open a Tkinter display window when gen_imgs.cake_data_in_one() calls plt.figure().

In headless environments (such as GitHub Actions), GUI backends like Tk are unavailable. This caused the test suite to fail or hang due to the attempt to create a display window.

Changes Made
Configured Matplotlib to use the non-interactive Agg backend at the beginning of the test file.
This ensures plots are rendered off-screen without requiring a display server.

Fixes test failures in headless CI environments.
Maintains existing test logic and coverage.
Improves reliability and portability of the test suite.