### PR TITLE
[BUG] Replace bare print with warning on non-convergence, fix ValueError format

### DIFF
--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -819,8 +819,7 @@ class GAM(Core, MetaTermMixin):
             return
 
         warnings.warn(
-            "PIRLS did not converge."
-            " Try increasing max_iter or decreasing tol.",
+            "PIRLS did not converge. Try increasing max_iter or decreasing tol.",
             stacklevel=2,
         )
         return

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -818,7 +818,11 @@ class GAM(Core, MetaTermMixin):
         if diff < self.tol:
             return
 
-        print("did not converge")
+        warnings.warn(
+            "PIRLS did not converge."
+            " Try increasing max_iter or decreasing tol.",
+            stacklevel=2,
+        )
         return
 
     def _on_loop_start(self, variables):
@@ -1194,8 +1198,7 @@ class GAM(Core, MetaTermMixin):
         """
         if gamma < 1:
             raise ValueError(
-                "gamma scaling should be greater than 1, but found gamma = {}",
-                format(gamma),
+                f"gamma scaling should be greater than 1, but found gamma = {gamma}"
             )
 
         if modelmat is None:

--- a/pygam/tests/test_GAM_methods.py
+++ b/pygam/tests/test_GAM_methods.py
@@ -476,9 +476,7 @@ def test_non_convergence_emits_warning(mcycle_X_y):
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         gam.fit(X, y)
-        convergence_warnings = [
-            x for x in w if "did not converge" in str(x.message)
-        ]
+        convergence_warnings = [x for x in w if "did not converge" in str(x.message)]
         assert len(convergence_warnings) == 1
 
 

--- a/pygam/tests/test_GAM_methods.py
+++ b/pygam/tests/test_GAM_methods.py
@@ -467,6 +467,31 @@ def test_fit_quantile_NOT_close_enough(head_circumference_X_y):
     assert np.abs(ratio - quantile) > tol
 
 
+def test_non_convergence_emits_warning(mcycle_X_y):
+    """Non-convergence should emit a warning, not print to stdout."""
+    X, y = mcycle_X_y
+    gam = LinearGAM(max_iter=1, tol=1e-100)
+    import warnings
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        gam.fit(X, y)
+        convergence_warnings = [
+            x for x in w if "did not converge" in str(x.message)
+        ]
+        assert len(convergence_warnings) == 1
+
+
+def test_GCV_UBRE_gamma_error_message(mcycle_X_y, mcycle_gam):
+    """ValueError for gamma < 1 should have a properly formatted message."""
+    with pytest.raises(ValueError, match=r"gamma.*0\.5"):
+        mcycle_gam._estimate_GCV_UBRE(
+            y=mcycle_X_y[1],
+            modelmat=mcycle_gam._modelmat(mcycle_X_y[0]),
+            gamma=0.5,
+        )
+
+
 def test_fit_quantile_raises_ValueError(head_circumference_X_y):
     """see that we DO NOT get fit on bad argument requests"""
     X, y = head_circumference_X_y


### PR DESCRIPTION
## Summary

Two bugs found by code review:

1. **`print("did not converge")` → `warnings.warn()`** (`pygam.py:821`)
   - Libraries should not use `print()` for user-facing messages. Replaced with `warnings.warn()` so users can programmatically capture/filter non-convergence events via Python's warning system.

2. **Malformed `ValueError` in `_estimate_GCV_UBRE`** (`pygam.py:1196-1199`)
   - `format(gamma)` was passed as a separate argument to `ValueError` instead of being interpolated into the string. This produced a confusing tuple error message:
     ```python
     # Before (broken):
     ValueError('gamma scaling should be greater than 1, but found gamma = {}', '0.5')
     
     # After (fixed):
     ValueError('gamma scaling should be greater than 1, but found gamma = 0.5')
     ```

## Test plan

- [x] Added `test_non_convergence_emits_warning` — verifies warning is emitted (not printed)
- [x] Added `test_GCV_UBRE_gamma_error_message` — verifies error message contains the actual gamma value
- [x] All 164 tests pass (162 existing + 2 new)