### PR TITLE
[BUG] Fix incorrect UBRE score: bitwise NOT (~) used instead of logical NOT

### DIFF
--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -1220,7 +1220,7 @@ class GAM(Core, MetaTermMixin):
             # scale is known, use UBRE
             scale = self.distribution.scale
             UBRE = (
-                1.0 / n * dev - (~add_scale) * (scale) + 2.0 * gamma / n * edof * scale
+                1.0 / n * dev - (not add_scale) * scale + 2.0 * gamma / n * edof * scale
             )
         else:
             # scale unknown, use GCV

--- a/pygam/tests/test_gridsearch.py
+++ b/pygam/tests/test_gridsearch.py
@@ -221,6 +221,47 @@ def test_UBRE_objective_is_for_known_scale(
             assert True
 
 
+def test_UBRE_formula_matches_wood(coal_X_y):
+    """Verify UBRE formula against Wood 2006 pg. 177.
+
+    UBRE = (1/n)*D + (2*gamma/n)*edof*scale - scale
+
+    When add_scale=True, scale is added back so the result is always positive:
+    UBRE_adj = (1/n)*D + (2*gamma/n)*edof*scale
+    """
+    X, y = coal_X_y
+    gam = PoissonGAM().fit(X, y)
+
+    modelmat = gam._modelmat(X)
+    n = len(y)
+    edof = gam.statistics_["edof"]
+    scale = gam.distribution.scale  # 1.0 for Poisson
+    gamma = 1.4
+    weights = np.ones_like(y, dtype="float64")
+
+    mu = gam.predict_mu(X)
+    dev = gam.distribution.deviance(mu=mu, y=y, scaled=False, weights=weights).sum()
+
+    # expected UBRE without scale adjustment (Wood 2006)
+    expected_no_add = dev / n - scale + 2.0 * gamma / n * edof * scale
+    # expected UBRE with scale added back
+    expected_add = dev / n + 2.0 * gamma / n * edof * scale
+
+    _, ubre_add = gam._estimate_GCV_UBRE(
+        modelmat=modelmat, y=y, gamma=gamma, add_scale=True, weights=weights
+    )
+    _, ubre_no_add = gam._estimate_GCV_UBRE(
+        modelmat=modelmat, y=y, gamma=gamma, add_scale=False, weights=weights
+    )
+
+    assert np.isclose(ubre_add, expected_add), (
+        f"UBRE (add_scale=True): got {ubre_add}, expected {expected_add}"
+    )
+    assert np.isclose(ubre_no_add, expected_no_add), (
+        f"UBRE (add_scale=False): got {ubre_no_add}, expected {expected_no_add}"
+    )
+
+
 def test_no_models_fitted(mcycle_X_y):
     """
     test no models fitted returns original gam


### PR DESCRIPTION
## Summary

The UBRE (Un-Biased Risk Estimator) formula in `_estimate_GCV_UBRE` uses `~add_scale` (bitwise NOT) where `not add_scale` (logical NOT) was intended.

In Python, `~True` evaluates to `-2` and `~False` to `-1`, **not** `0` and `1` as expected:

```python
>>> ~True   # -2, not 0
>>> ~False  # -1, not 1
```

This causes the UBRE score to be inflated by `2 * scale` for every model with known scale (Poisson, Binomial). For Poisson models (`scale=1`), the reported UBRE is off by +2.0:

```python
# Before (buggy):  UBRE = dev/n + 2*scale + 2*γ*edof*scale/n
# After (correct):  UBRE = dev/n + 2*γ*edof*scale/n
# Reference: Wood 2006, section 4.5.1, pg 177-182
```

**Impact**: While model selection via gridsearch is unaffected (constant offset doesn't change ranking), the UBRE values stored in `statistics_["UBRE"]` are incorrect. This matters for users who inspect or compare UBRE scores directly.

**Fix**: Replace `~add_scale` with `not add_scale` on line 1223.

## Test plan

- [x] Added `test_UBRE_formula_matches_wood` — verifies UBRE against the analytical formula from Wood 2006 for both `add_scale=True` and `add_scale=False`
- [x] All 163 tests pass
- [x] Pre-formatted with `ruff format`