### PR TITLE
Fix nested parameter routing in set_params for term-specific parameters

### DIFF
--- a/pygam/core.py
+++ b/pygam/core.py
@@ -184,34 +184,27 @@ class Core:
         param_names = self.get_params(deep=deep).keys()
         for parameter, value in parameters.items():
             if "__" in parameter:
-                parts=parameter.split("__")
-                obj=self
+                parts = parameter.split("__")
+                obj = self
                 try:
                     for part in parts[:-1]:
                         if part.isdigit():
-                            obj=obj[int(part)]
+                            obj = obj[int(part)]
                         else:
-                            obj=getattr(obj,part)
-                    final_part=parts[-1]
-                    if final_part!= final_part.strip("_"):
-                        raise ValueError(
-                            f"Cannot set private parameter '{final_attr}'"
-                        )
+                            obj = getattr(obj, part)
+                    final_part = parts[-1]
+                    if final_part != final_part.strip("_"):
+                        raise ValueError(f"Cannot set private parameter '{final_part}'")
                     setattr(obj, final_part, value)
                 except (AttributeError, IndexError, TypeError) as e:
-                    raise ValueError(
-                        f"Invalid parameter path: '{parameter}'"
-                    ) from e
+                    raise ValueError(f"Invalid parameter path: '{parameter}'") from e
 
                 continue
             if (
                 parameter in param_names
                 or force
-                or (
-                    hasattr(self, parameter)
-                    and parameter == parameter.strip("_")
-                )
+                or (hasattr(self, parameter) and parameter == parameter.strip("_"))
             ):
                 setattr(self, parameter, value)
-                    
+
         return self

--- a/pygam/core.py
+++ b/pygam/core.py
@@ -183,10 +183,35 @@ class Core:
         """
         param_names = self.get_params(deep=deep).keys()
         for parameter, value in parameters.items():
+            if "__" in parameter:
+                parts=parameter.split("__")
+                obj=self
+                try:
+                    for part in parts[:-1]:
+                        if part.isdigit():
+                            obj=obj[int(part)]
+                        else:
+                            obj=getattr(obj,part)
+                    final_part=parts[-1]
+                    if final_part!= final_part.strip("_"):
+                        raise ValueError(
+                            f"Cannot set private parameter '{final_attr}'"
+                        )
+                    setattr(obj, final_part, value)
+                except (AttributeError, IndexError, TypeError) as e:
+                    raise ValueError(
+                        f"Invalid parameter path: '{parameter}'"
+                    ) from e
+
+                continue
             if (
                 parameter in param_names
                 or force
-                or (hasattr(self, parameter) and parameter == parameter.strip("_"))
+                or (
+                    hasattr(self, parameter)
+                    and parameter == parameter.strip("_")
+                )
             ):
                 setattr(self, parameter, value)
+                    
         return self

--- a/pygam/tests/test_GAM_params.py
+++ b/pygam/tests/test_GAM_params.py
@@ -107,7 +107,7 @@ class TestRegressions:
         X, y = mcycle_X_y
         gam = LinearGAM(n_splines=np.arange(9, 10)[0]).fit(X, y)
         assert gam._is_fitted
-        
+
     def test_nested_set_params_updates_term(self):
         """
         nested sklearn-style parameters should update term attributes

--- a/pygam/tests/test_GAM_params.py
+++ b/pygam/tests/test_GAM_params.py
@@ -107,6 +107,14 @@ class TestRegressions:
         X, y = mcycle_X_y
         gam = LinearGAM(n_splines=np.arange(9, 10)[0]).fit(X, y)
         assert gam._is_fitted
+        
+    def test_nested_set_params_updates_term(self):
+        """
+        nested sklearn-style parameters should update term attributes
+        """
+        gam = LinearGAM(s(0, n_splines=10))
+        gam.set_params(terms__0__n_splines=30)
+        assert gam.terms[0].n_splines == 30
 
 
 # TODO categorical dtypes get no fit linear even if fit linear TRUE


### PR DESCRIPTION
This PR adds support for sklearn-style nested parameter routing in set_params.
Previously, nested parameters such as:

`gam.set_params(terms__0__n_splines=30)`

were treated as literal attribute names and silently ignored. As a result, term-specific hyperparameter tuning through tools such as `GridSearchCV` would not actually modify the underlying terms.

Referencing: #580 

Changes:
Added support for resolving nested parameter paths containing `__`.
Added a regression test covering term-specific parameter updates.