### PR TITLE
Improved p-values for smooth terms (Wood 2013b). Fixes #163.

### DIFF
--- a/gen_imgs.py
+++ b/gen_imgs.py
@@ -323,7 +323,6 @@ def chicago_tensor():
 
 
 def expectiles():
-
     """Generate expectiles visualization."""
     X, y = mcycle(return_X_y=True)
 

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -1032,7 +1032,7 @@ class GAM(Core, MetaTermMixin):
         mu = self.link.mu(lp, self.distribution)
 
         self._modelmat_train_ = modelmat
-        F = U1.dot(U1.T)  # m×m hat matrix
+        F = U1.dot(U1.T)  # mxm hat matrix
         F2_diag = np.diag(F.dot(F))  # diag(F²)
 
         self.statistics_["edof_per_coef"] = np.diag(F)  # diag(F) - unchanged
@@ -1360,7 +1360,7 @@ class GAM(Core, MetaTermMixin):
         pvals = np.array([self._liu2(xi, val) for xi in x_pts])
         return float(np.clip(pvals.mean(), 0.0, 1.0))
 
-    def _woodteststat(self, coef_j, Vbj, edf_j, res_df=-1):
+    def _woodteststat(self, coef_j, Vbj, edf_j, Xj=[[1, 0], [0, 1]], res_df=-1):
         """
         Wood (2013) test statistic and p-value for a smooth term.
 
@@ -1378,6 +1378,9 @@ class GAM(Core, MetaTermMixin):
         coef_j = np.asarray(coef_j, dtype=float)
 
         # ---- STAGE A: break the covariance into directions + their sizes ----
+        Xj = np.asarray(Xj, dtype=float)
+        Xj = Xj - Xj.mean(axis=0)
+        _, R = np.linalg.qr(Xj)
         Vbj = np.asarray(Vbj, dtype=float)
         Vbj = (Vbj + Vbj.T) * 0.5
         eigvals, eigvecs = np.linalg.eigh(Vbj)
@@ -1522,7 +1525,7 @@ class GAM(Core, MetaTermMixin):
         Vbj = self.statistics_["cov"][valid_idxs][:, valid_idxs]
         coef = self.coef_[valid_idxs].copy()
 
-
+        Xj = np.asarray(self._modelmat_train_[:, valid_idxs].todense())
 
         edf_j = float(edf1_arr[valid_idxs].sum())
         edf_j = max(edf_j, 1e-6)
@@ -1532,7 +1535,7 @@ class GAM(Core, MetaTermMixin):
         else:
             res_df = self.statistics_["n_samples"] - self.statistics_["edof"]
 
-        _, pval, _ = self._woodteststat(coef, Vbj, edf_j, res_df)
+        _, pval, _ = self._woodteststat(coef, Vbj, edf_j, Xj, res_df)
         return pval
 
     def confidence_intervals(self, X, width=0.95, quantiles=None):
@@ -2035,8 +2038,6 @@ class GAM(Core, MetaTermMixin):
             "         known smoothing parameters, but when smoothing parameters have been estimated, the p-values\n"  # noqa: E501
             "         are typically lower than they should be, meaning that the tests reject the null too readily."  # noqa: E501
         )
-
-
 
     def gridsearch(
         self,

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -1360,7 +1360,7 @@ class GAM(Core, MetaTermMixin):
         pvals = np.array([self._liu2(xi, val) for xi in x_pts])
         return float(np.clip(pvals.mean(), 0.0, 1.0))
 
-    def _woodteststat(self, coef_j, Vbj, edf_j, Xj=[[1, 0], [0, 1]], res_df=-1):
+    def _woodteststat(self, coef_j, Vbj, edf_j, Xj, res_df=-1):
         """
         Wood (2013) test statistic and p-value for a smooth term.
 
@@ -1383,6 +1383,8 @@ class GAM(Core, MetaTermMixin):
         _, R = np.linalg.qr(Xj)
         Vbj = np.asarray(Vbj, dtype=float)
         Vbj = (Vbj + Vbj.T) * 0.5
+        Vbj = R.dot(Vbj).dot(R.T)
+        coef_j = R.dot(coef_j)
         eigvals, eigvecs = np.linalg.eigh(Vbj)
         eigvals = eigvals[::-1]
         eigvecs = eigvecs[:, ::-1]

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -1366,9 +1366,10 @@ class GAM(Core, MetaTermMixin):
 
         Parameters
         ----------
-        coef_j : (q,) array   - the coefficients for term j (beta_hat_j)
+        coef_j : (q,) array   - the coefficients for term j (Bj)
         Vbj    : (q, q) array - covariance of those coefficients
         edf_j  : float        - effective degrees of freedom tau (e.g. 3.7)
+        Xj     : (n, q) array - the model matrix for term j
         res_df : float        - residual dof (or -1 if scale is known)
 
         Returns
@@ -1388,6 +1389,36 @@ class GAM(Core, MetaTermMixin):
         eigvals, eigvecs = np.linalg.eigh(Vbj)
         eigvals = eigvals[::-1]
         eigvecs = eigvecs[:, ::-1]
+
+        """
+        Derivation is as Follows
+
+        1)fj = Xj Bj                 
+
+        2)Vfj = Xj Vbj Xj.T
+
+        3)T = fj.T Vfj(r-) fj Given in Wood 2013b as the Wald Statistic to be used for the test of the smooth term.
+
+        4)Xj = Q R
+
+        5)Vfj(r-) = (Xj Vbj Xj.T)(r-) = ((Q R)(Vbj)(R.T Q.T)) (r-) = Q (R Vbj R.T)(r) Q.T [put 4 in 2]
+
+        6)T = (Bj.T Xj.T) (Q (R Vbj R.T)(r-) Q.T) (Xj Bj) [put 5 and 1 in 3]
+
+        7)T = Bj.T R.T Q.T Q (R Vbj R.T)(r-) Q.T Q R Bj [put 4 in 6] = Bj.T R.T (R Vbj R.T)(r-) R Bj  [Because Q Q.T = I]
+
+        Let us put W = R Vbj R.T
+
+        Thus T = Bj.T R.T W(r-) R Bj = |vec R Bj|^2 where vec is the rank truncated pseudo inverse with the factors scaled by roots  
+
+        Efficiency:
+
+        Vfj [nxn] =   Xj [nxq] Vbj [qxq] Xj.T [qxn]
+
+        W [qxq] = R [qxq] Vbj [qxq]  R.T [qxq] 
+
+        Hence, To calculate T, we only need R, Bj, Vbj
+        """
 
         # match mgcv's sign convention: force first row of each eigenvector >= 0
         # (eigenvectors are sign-ambiguous; this pins them so T matches mgcv exactly)

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -2038,15 +2038,7 @@ class GAM(Core, MetaTermMixin):
             "         are typically lower than they should be, meaning that the tests reject the null too readily."  # noqa: E501
         )
 
-        # P-VALUE BUG
-        warnings.warn(
-            "KNOWN BUG: p-values computed in this summary are likely "
-            "much smaller than they should be. \n \n"
-            "Please do not make inferences based on these values! \n\n"
-            "Collaborate on a solution, and stay up to date at: \n"
-            "github.com/dswah/pyGAM/issues/163 \n",
-            stacklevel=2,
-        )
+
 
     def gridsearch(
         self,

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -1030,8 +1030,17 @@ class GAM(Core, MetaTermMixin):
         """
         lp = self._linear_predictor(modelmat=modelmat)
         mu = self.link.mu(lp, self.distribution)
-        self.statistics_["edof_per_coef"] = np.diagonal(U1.dot(U1.T))
-        self.statistics_["edof"] = self.statistics_["edof_per_coef"].sum()
+
+        self._modelmat_train_ = modelmat
+        F = U1.dot(U1.T)  # m×m hat matrix
+        F2_diag = np.diag(F.dot(F))  # diag(F²)
+
+        self.statistics_["edof_per_coef"] = np.diag(F)  # diag(F) - unchanged
+        self.statistics_["edf1_per_coef"] = (
+            2.0 * np.diag(F) - F2_diag
+        )  # NEW: tr(2F - F²) per coef
+        self.statistics_["edof"] = self.statistics_["edof_per_coef"].sum()  # unchanged
+
         if not self.distribution._known_scale:
             self.distribution.scale = (
                 self.distribution.phi(
@@ -1237,6 +1246,119 @@ class GAM(Core, MetaTermMixin):
             p_values.append(self._compute_p_value(term_i))
 
         return p_values
+
+    def _liu2(self, x, lambdas):
+        """
+        Approximate P(Q > x) where Q = sum_i lambda_i * chi2_1.
+
+        Parameters
+        ----------
+        x : float
+            Threshold value (the test statistic T_tau in the GAM context).
+        lambdas : array-like
+            Mixture weights. In Wood (2013) these are [1, 1, ..., 1, nu1, nu2].
+
+        Returns
+        -------
+        float
+            Approximate upper-tail probability, in [0, 1].
+
+        Notes
+        -----
+        Cumulant-matching approximation. Find a non-central chi-squared
+        distribution whose first four cumulants match Q, then use its exact tail.
+
+        Uses s2 = sum(lambda^4) / c2^2 per Liu et al. (2009) paper.
+        """
+        lam = np.asarray(lambdas, dtype=float)
+
+        # Degenerate inputs
+        if lam.size == 0:
+            return 1.0
+        if np.all(lam == 0):
+            return 1.0 if x <= 0 else 0.0
+
+        # Cumulants by successive multiplication
+        lh = lam.copy()
+        muQ = lh.sum()  # = sum(lambda)
+        lh = lh * lam
+        c2 = lh.sum()  # = sum(lambda^2)
+        lh = lh * lam
+        c3 = lh.sum()  # = sum(lambda^3)
+        lh = lh * lam  # lh now = lambda^4
+        c4 = lh.sum()  # = sum(lambda^4)
+
+        # Underflow guard
+        if c2 <= 1e-300:
+            return 1.0 if x <= muQ else 0.0
+
+        # Skewness and 4th-cumulant ratio (PAPER formula)
+        s1 = c3 / (c2**1.5)
+        s2 = c4 / (c2**2)  # <<<< PAPER: lambda^4
+
+        sigQ = np.sqrt(2.0 * c2)
+        t = (x - muQ) / sigQ  # standardised value
+
+        # Match to non-central chi-squared parameters
+        if s1**2 > s2 and (s1**2 - s2) > 1e-14 * max(s1**2, 1e-300):
+            denom = s1 - np.sqrt(s1**2 - s2)
+            if denom <= 0:
+                return float(sp.stats.norm.sf(t))
+            a = 1.0 / denom
+            delta = s1 * a**3 - a**2
+            l = a**2 - 2.0 * delta
+            if not np.isfinite(a) or not np.isfinite(l) or l <= 0 or delta < -1e-6:
+                return float(sp.stats.norm.sf(t))
+        else:
+            if s1 == 0.0:
+                return float(sp.stats.norm.sf(t))
+            a = 1.0 / s1
+            delta = 0.0
+            if c3 == 0.0:
+                return 1.0 if x <= muQ else 0.0
+            l = (c2**3) / (c3**2)
+
+        # Numerical safeguards
+        delta = max(delta, 0.0)
+        l = max(l, 1e-10)
+
+        muX = l + delta
+        sigX = np.sqrt(2.0) * a
+
+        chi2_value = t * sigX + muX
+        pval = sp.stats.ncx2.sf(chi2_value, df=l, nc=delta)
+        return float(np.clip(pval, 0.0, 1.0))
+
+    def _liu2_scaled_quadrature(self, d, val, k0, nq=50):
+        """
+        Approximate P(Q > d * chi2_{k0} / k0) where Q = sum_i val_i * chi2_1.
+
+        For Wood (2013) when scale is estimated (Gaussian, Gamma GAMs).
+        Midpoint quadrature over chi2_{k0} distribution.
+
+        Parameters
+        ----------
+        d : float
+            Test statistic.
+        val : array-like
+            Mixture weights for Q.
+        k0 : int
+            Residual degrees of freedom (>= 1).
+        nq : int
+            Number of quadrature points (default 50, as in mgcv's simf).
+
+        Returns
+        -------
+        float : P(Q > d * chi2_{k0} / k0), in [0, 1].
+        """
+        k0 = int(max(1, k0))
+        nq = int(max(1, nq))
+
+        p_pts = (np.arange(1, nq + 1) - 0.5) / nq
+        q_pts = sp.stats.chi2.ppf(p_pts, df=k0)
+        x_pts = d * q_pts / k0
+        pvals = np.array([self._liu2(xi, val) for xi in x_pts])
+        return float(np.clip(pvals.mean(), 0.0, 1.0))
 
     def _compute_p_value(self, term_i):
         """Compute the p-value of the desired feature.

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -1522,9 +1522,7 @@ class GAM(Core, MetaTermMixin):
         Vbj = self.statistics_["cov"][valid_idxs][:, valid_idxs]
         coef = self.coef_[valid_idxs].copy()
 
-        # center spline term coefficients (smooth/intercept identifiability)
-        if isinstance(self.terms[term_i], SplineTerm):
-            coef = coef - coef.mean()
+
 
         edf_j = float(edf1_arr[valid_idxs].sum())
         edf_j = max(edf_j, 1e-6)

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -1393,7 +1393,7 @@ class GAM(Core, MetaTermMixin):
         """
         Derivation is as Follows
 
-        1)fj = Xj Bj                 
+        1)fj = Xj Bj
 
         2)Vfj = Xj Vbj Xj.T
 
@@ -1409,13 +1409,13 @@ class GAM(Core, MetaTermMixin):
 
         Let us put W = R Vbj R.T
 
-        Thus T = Bj.T R.T W(r-) R Bj = |vec R Bj|^2 where vec is the rank truncated pseudo inverse with the factors scaled by roots  
+        Thus T = Bj.T R.T W(r-) R Bj = |vec R Bj|^2 where vec is the rank truncated pseudo inverse with the factors scaled by roots
 
         Efficiency:
 
         Vfj [nxn] =   Xj [nxq] Vbj [qxq] Xj.T [qxn]
 
-        W [qxq] = R [qxq] Vbj [qxq]  R.T [qxq] 
+        W [qxq] = R [qxq] Vbj [qxq]  R.T [qxq]
 
         Hence, To calculate T, we only need R, Bj, Vbj
         """

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -1364,9 +1364,19 @@ class GAM(Core, MetaTermMixin):
         """
         Wood (2013) test statistic and p-value for a smooth term.
 
+        Computes T_r = delta1^T delta1 + delta2^T B_tilde delta2 directly, as
+        given in Wood (2013) sections 2.2-2.3. The term's model matrix Xj is
+        column-centred and QR-decomposed; because Xj = Q R with Q^T Q = I, the
+        curve-space statistic reduces to a small computation on W = R Vbj R^T,
+        which shares the nonzero eigenvalues of the curve covariance Xj Vbj Xj^T.
+
+        The boundary cross-term has an unresolvable eigenvector-sign ambiguity,
+        so the p-value averages the two sign choices (B_tilde with +rho and
+        -rho), matching mgcv's two-statistic average.
+
         Parameters
         ----------
-        coef_j : (q,) array   - the coefficients for term j (Bj)
+        coef_j : (q,) array   - coefficients for term j (beta_hat_j)
         Vbj    : (q, q) array - covariance of those coefficients
         edf_j  : float        - effective degrees of freedom tau (e.g. 3.7)
         Xj     : (n, q) array - the model matrix for term j
@@ -1374,147 +1384,98 @@ class GAM(Core, MetaTermMixin):
 
         Returns
         -------
-        (T, pval, rank) : test statistic, p-value, integer rank used
+        (T, pval, rank)
         """
         coef_j = np.asarray(coef_j, dtype=float)
 
-        # ---- STAGE A: break the covariance into directions + their sizes ----
+        # rotate into curve space: W = R Vbj R^T, shares curve-covariance eigenvalues
         Xj = np.asarray(Xj, dtype=float)
         Xj = Xj - Xj.mean(axis=0)
         _, R = np.linalg.qr(Xj)
         Vbj = np.asarray(Vbj, dtype=float)
         Vbj = (Vbj + Vbj.T) * 0.5
-        Vbj = R.dot(Vbj).dot(R.T)
-        coef_j = R.dot(coef_j)
-        eigvals, eigvecs = np.linalg.eigh(Vbj)
-        eigvals = eigvals[::-1]
-        eigvecs = eigvecs[:, ::-1]
+        W = R.dot(Vbj).dot(R.T)
+        W = (W + W.T) * 0.5
+        Rc = R.dot(coef_j)  # R beta_hat_j
 
-        """
-        Derivation is as Follows
+        # eigen-basis of the curve covariance
+        lam, U = np.linalg.eigh(W)
+        lam = lam[::-1]
+        U = U[:, ::-1]
 
-        1)fj = Xj Bj
-
-        2)Vfj = Xj Vbj Xj.T
-
-        3)T = fj.T Vfj(r-) fj Given in Wood 2013b as the Wald Statistic to be used for the test of the smooth term.
-
-        4)Xj = Q R
-
-        5)Vfj(r-) = (Xj Vbj Xj.T)(r-) = ((Q R)(Vbj)(R.T Q.T)) (r-) = Q (R Vbj R.T)(r) Q.T [put 4 in 2]
-
-        6)T = (Bj.T Xj.T) (Q (R Vbj R.T)(r-) Q.T) (Xj Bj) [put 5 and 1 in 3]
-
-        7)T = Bj.T R.T Q.T Q (R Vbj R.T)(r-) Q.T Q R Bj [put 4 in 6] = Bj.T R.T (R Vbj R.T)(r-) R Bj  [Because Q Q.T = I]
-
-        Let us put W = R Vbj R.T
-
-        Thus T = Bj.T R.T W(r-) R Bj = |vec R Bj|^2 where vec is the rank truncated pseudo inverse with the factors scaled by roots
-
-        Efficiency:
-
-        Vfj [nxn] =   Xj [nxq] Vbj [qxq] Xj.T [qxn]
-
-        W [qxq] = R [qxq] Vbj [qxq]  R.T [qxq]
-
-        Hence, To calculate T, we only need R, Bj, Vbj
-        """
-
-        # match mgcv's sign convention: force first row of each eigenvector >= 0
-        # (eigenvectors are sign-ambiguous; this pins them so T matches mgcv exactly)
-        siv = np.sign(eigvecs[0, :])
+        # eigenvectors are sign-ambiguous; pin the first row >= 0 so the boundary
+        # cross-term is deterministic (a numerical convention, not from the paper)
+        siv = np.sign(U[0, :])
         siv[siv == 0] = 1.0
-        eigvecs = eigvecs * siv
+        U = U * siv
 
-        # ---- STAGE B: split tau into whole part k and leftover nu ----
+        # split tau into whole part and fractional part
         tau = float(edf_j)
         k = int(np.floor(tau))
         nu = tau - k
         k1 = k + 1 if nu > 0 else k
 
-        # ---- STAGE C: don't use directions whose eigenvalue is ~0 ----
-        if eigvals[0] > 0:
-            tol = max(eigvals[0] * (np.finfo(float).eps ** 0.9), 1e-15)
+        # discard heavily-penalised (near-zero eigenvalue) directions
+        if lam[0] > 0:
+            tol = max(lam[0] * (np.finfo(float).eps ** 0.9), 1e-15)
         else:
             tol = 0.0
-        r_usable = int(np.sum(eigvals > tol))
-
-        # if Vbj is degenerate (no real directions), term is effectively zero
+        r_usable = int(np.sum(lam > tol))
         if r_usable == 0:
             return 0.0, 1.0, 1
-
         if r_usable < k1:
-            k1 = r_usable
-            k = r_usable
+            k1 = k = r_usable
             nu = 0.0
             tau = float(r_usable)
 
-        # ---- STAGE D: build the scaled eigenvectors `vec` and the weights ----
+        # whitened projections d_i = u_i^T (R beta) / sqrt(lambda_i)
+        d = U.T.dot(Rc)
+
         if nu > 0 and k > 0:
-            # keep the top k1 directions
-            vec = eigvecs[:, :k1].copy()
-
-            # (a) fully invert the top k-1 directions: divide each by sqrt(eigenvalue)
+            # delta1: fully inverted directions -> sum of squares  (Wood: delta1^T delta1)
             if k > 1:
-                vec[:, : k - 1] = vec[:, : k - 1] / np.sqrt(eigvals[: k - 1])
+                delta1 = d[: k - 1] / np.sqrt(lam[: k - 1])
+                T_solid = float(delta1.dot(delta1))
+            else:
+                T_solid = 0.0
 
-            # (b) partially invert the last 2 directions via the B-tilde block
+            # delta2: boundary pair, weighted by B_tilde  (Wood: delta2^T B_tilde delta2)
+            # evaluate with +rho and -rho (the two eigenvector-sign choices)
             rho = np.sqrt(max(0.0, 0.5 * nu * (1.0 - nu)))
-            B_tilde = np.array([[1.0, rho], [rho, nu]])
-            ev_scale = np.diag(eigvals[k - 1 : k1] ** -0.5)
-            B = ev_scale @ B_tilde @ ev_scale
+            B_plus = np.array([[1.0, rho], [rho, nu]])
+            B_minus = np.array([[1.0, -rho], [-rho, nu]])
+            delta2 = np.array([d[k - 1] / np.sqrt(lam[k - 1]), d[k] / np.sqrt(lam[k])])
+            T = T_solid + float(delta2.dot(B_plus).dot(delta2))
+            T_alt = T_solid + float(delta2.dot(B_minus).dot(delta2))
 
-            # matrix square-root of B
-            eb_vals, eb_vecs = np.linalg.eigh(B)
-            rB = eb_vecs @ np.diag(np.sqrt(np.maximum(eb_vals, 0.0))) @ eb_vecs.T
-
-            # sign-flipped copy resolves the matrix-sqrt sign ambiguity
-            vec1 = vec.copy()
-            sign_flip = np.diag([-1.0, 1.0])
-            vec1[:, k - 1 : k1] = (rB @ sign_flip @ vec[:, k - 1 : k1].T).T
-            vec[:, k - 1 : k1] = (rB @ vec[:, k - 1 : k1].T).T
-
-            # (c) mixture weights for liu2: [1, 1, ..., nu1, nu2]
+            # mixture weights for the reference distribution: [1, ..., 1, nu1, nu2]
             rp = nu + 1.0
             weights = np.ones(k1)
             weights[k - 1] = (rp + np.sqrt(rp * (2.0 - rp))) / 2.0
             weights[k] = rp - weights[k - 1]
-        else:
-            # integer case: fully invert all k directions, all weights = 1
-            kk = max(1, k)
-            vec = eigvecs[:, :kk].copy()
-            vec = vec / np.sqrt(np.maximum(eigvals[:kk], 1e-300))
-            vec1 = vec.copy()
-            weights = np.ones(kk)
 
-        # ---- STAGE E: test statistic ----
-        proj = vec.T.dot(coef_j)
-        T = float(proj.dot(proj))
-        proj1 = vec1.T.dot(coef_j)
-        T1 = float(proj1.dot(proj1))
-
-        # ---- STAGE F: p-value ----
-        rank = max(1, int(round(tau)))
-        if nu > 0:
+            # p-value from the chi-squared mixture (Liu et al. 2009), averaging
+            # the two boundary-sign choices; F-analogue when the scale is estimated
             if res_df <= 0:
-                pval = 0.5 * (self._liu2(T, weights) + self._liu2(T1, weights))
+                pval = 0.5 * (self._liu2(T, weights) + self._liu2(T_alt, weights))
             else:
                 k0 = max(1, int(round(res_df)))
                 pval = 0.5 * (
                     self._liu2_scaled_quadrature(T, weights, k0)
-                    + self._liu2_scaled_quadrature(T1, weights, k0)
+                    + self._liu2_scaled_quadrature(T_alt, weights, k0)
                 )
         else:
+            # integer case: fully invert all k directions, reference is chi^2_k / F
+            kk = max(1, k)
+            delta = d[:kk] / np.sqrt(np.maximum(lam[:kk], 1e-300))
+            T = float(delta.dot(delta))
+            rank = max(1, int(round(tau)))
             if res_df <= 0:
-                pval = 0.5 * (
-                    sp.stats.chi2.sf(T, df=rank) + sp.stats.chi2.sf(T1, df=rank)
-                )
+                pval = sp.stats.chi2.sf(T, df=rank)
             else:
-                pval = 0.5 * (
-                    sp.stats.f.sf(T / rank, rank, res_df)
-                    + sp.stats.f.sf(T1 / rank, rank, res_df)
-                )
+                pval = sp.stats.f.sf(T / rank, rank, res_df)
 
+        rank = max(1, int(round(tau)))
         return float(T), float(np.clip(pval, 0.0, 1.0)), rank
 
     def _compute_p_value(self, term_i):
@@ -1529,7 +1490,7 @@ class GAM(Core, MetaTermMixin):
         Arguments
         ---------
         term_i : int
-            term to select from the data
+            term to select from the dataz
 
         Returns
         -------

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -1360,8 +1360,135 @@ class GAM(Core, MetaTermMixin):
         pvals = np.array([self._liu2(xi, val) for xi in x_pts])
         return float(np.clip(pvals.mean(), 0.0, 1.0))
 
+    def _woodteststat(self, coef_j, Vbj, edf_j, res_df=-1):
+        """
+        Wood (2013) test statistic and p-value for a smooth term.
+
+        Parameters
+        ----------
+        coef_j : (q,) array   - the coefficients for term j (beta_hat_j)
+        Vbj    : (q, q) array - covariance of those coefficients
+        edf_j  : float        - effective degrees of freedom tau (e.g. 3.7)
+        res_df : float        - residual dof (or -1 if scale is known)
+
+        Returns
+        -------
+        (T, pval, rank) : test statistic, p-value, integer rank used
+        """
+        coef_j = np.asarray(coef_j, dtype=float)
+
+        # ---- STAGE A: break the covariance into directions + their sizes ----
+        Vbj = np.asarray(Vbj, dtype=float)
+        Vbj = (Vbj + Vbj.T) * 0.5
+        eigvals, eigvecs = np.linalg.eigh(Vbj)
+        eigvals = eigvals[::-1]
+        eigvecs = eigvecs[:, ::-1]
+
+        # match mgcv's sign convention: force first row of each eigenvector >= 0
+        # (eigenvectors are sign-ambiguous; this pins them so T matches mgcv exactly)
+        siv = np.sign(eigvecs[0, :])
+        siv[siv == 0] = 1.0
+        eigvecs = eigvecs * siv
+
+        # ---- STAGE B: split tau into whole part k and leftover nu ----
+        tau = float(edf_j)
+        k = int(np.floor(tau))
+        nu = tau - k
+        k1 = k + 1 if nu > 0 else k
+
+        # ---- STAGE C: don't use directions whose eigenvalue is ~0 ----
+        if eigvals[0] > 0:
+            tol = max(eigvals[0] * (np.finfo(float).eps ** 0.9), 1e-15)
+        else:
+            tol = 0.0
+        r_usable = int(np.sum(eigvals > tol))
+
+        # if Vbj is degenerate (no real directions), term is effectively zero
+        if r_usable == 0:
+            return 0.0, 1.0, 1
+
+        if r_usable < k1:
+            k1 = r_usable
+            k = r_usable
+            nu = 0.0
+            tau = float(r_usable)
+
+        # ---- STAGE D: build the scaled eigenvectors `vec` and the weights ----
+        if nu > 0 and k > 0:
+            # keep the top k1 directions
+            vec = eigvecs[:, :k1].copy()
+
+            # (a) fully invert the top k-1 directions: divide each by sqrt(eigenvalue)
+            if k > 1:
+                vec[:, : k - 1] = vec[:, : k - 1] / np.sqrt(eigvals[: k - 1])
+
+            # (b) partially invert the last 2 directions via the B-tilde block
+            rho = np.sqrt(max(0.0, 0.5 * nu * (1.0 - nu)))
+            B_tilde = np.array([[1.0, rho], [rho, nu]])
+            ev_scale = np.diag(eigvals[k - 1 : k1] ** -0.5)
+            B = ev_scale @ B_tilde @ ev_scale
+
+            # matrix square-root of B
+            eb_vals, eb_vecs = np.linalg.eigh(B)
+            rB = eb_vecs @ np.diag(np.sqrt(np.maximum(eb_vals, 0.0))) @ eb_vecs.T
+
+            # sign-flipped copy resolves the matrix-sqrt sign ambiguity
+            vec1 = vec.copy()
+            sign_flip = np.diag([-1.0, 1.0])
+            vec1[:, k - 1 : k1] = (rB @ sign_flip @ vec[:, k - 1 : k1].T).T
+            vec[:, k - 1 : k1] = (rB @ vec[:, k - 1 : k1].T).T
+
+            # (c) mixture weights for liu2: [1, 1, ..., nu1, nu2]
+            rp = nu + 1.0
+            weights = np.ones(k1)
+            weights[k - 1] = (rp + np.sqrt(rp * (2.0 - rp))) / 2.0
+            weights[k] = rp - weights[k - 1]
+        else:
+            # integer case: fully invert all k directions, all weights = 1
+            kk = max(1, k)
+            vec = eigvecs[:, :kk].copy()
+            vec = vec / np.sqrt(np.maximum(eigvals[:kk], 1e-300))
+            vec1 = vec.copy()
+            weights = np.ones(kk)
+
+        # ---- STAGE E: test statistic ----
+        proj = vec.T.dot(coef_j)
+        T = float(proj.dot(proj))
+        proj1 = vec1.T.dot(coef_j)
+        T1 = float(proj1.dot(proj1))
+
+        # ---- STAGE F: p-value ----
+        rank = max(1, int(round(tau)))
+        if nu > 0:
+            if res_df <= 0:
+                pval = 0.5 * (self._liu2(T, weights) + self._liu2(T1, weights))
+            else:
+                k0 = max(1, int(round(res_df)))
+                pval = 0.5 * (
+                    self._liu2_scaled_quadrature(T, weights, k0)
+                    + self._liu2_scaled_quadrature(T1, weights, k0)
+                )
+        else:
+            if res_df <= 0:
+                pval = 0.5 * (
+                    sp.stats.chi2.sf(T, df=rank) + sp.stats.chi2.sf(T1, df=rank)
+                )
+            else:
+                pval = 0.5 * (
+                    sp.stats.f.sf(T / rank, rank, res_df)
+                    + sp.stats.f.sf(T1 / rank, rank, res_df)
+                )
+
+        return float(T), float(np.clip(pval, 0.0, 1.0)), rank
+
     def _compute_p_value(self, term_i):
         """Compute the p-value of the desired feature.
+
+        Uses Wood (2013), "On p-values for smooth components of an extended
+        generalized additive model", Biometrika 100(1), 221-228. The reference
+        distribution is a chi-squared mixture evaluated via the Liu et al.
+        (2009) approximation (or an F-test analogue when the scale is
+        estimated).
 
         Arguments
         ---------
@@ -1371,50 +1498,44 @@ class GAM(Core, MetaTermMixin):
         Returns
         -------
         p_value : float
-
-        Notes
-        -----
-        Wood 2006, section 4.8.5:
-            The p-values, calculated in this manner, behave correctly for un-penalized
-            models, or models with known smoothing parameters, but when smoothing
-            parameters have been estimated, the p-values are typically lower than they
-            should be, meaning that the tests reject the null too readily.
-
-                (...)
-
-            In practical terms, if these p-values suggest that a term is not needed in
-            a model, then this is probably true, but if a term is deemed ‘significant’
-            it is important to be aware that this significance may be overstated.
-
-        based on equations from Wood 2006 section 4.8.5 page 191
-        and errata https://people.maths.bris.ac.uk/~sw15190/igam/iGAMerrata-12.pdf
-
-        the errata show a correction for the f-statistic.
+            p-value for H_0: term j is zero.
+            Returns float('nan') for the intercept (no test).
         """
         if not self._is_fitted:
             raise AttributeError("GAM has not been fitted. Call fit first.")
 
+        # intercept has no meaningful "is it zero?" test
+        if self.terms[term_i].isintercept:
+            return float("nan")
+
         idxs = self.terms.get_coef_indices(term_i)
-        cov = self.statistics_["cov"][idxs][:, idxs]
-        coef = self.coef_[idxs]
 
-        # center non-intercept term functions
+        # When n_coefs > min(n_samples, n_features), edf1_per_coef is shorter
+        # than the coef vector. Skip out-of-bounds indices; if all are out of
+        # bounds, return nan (term is in the unidentified extension).
+        edf1_arr = self.statistics_["edf1_per_coef"]
+        valid_mask = np.asarray(idxs) < len(edf1_arr)
+        if not valid_mask.any():
+            return float("nan")
+        valid_idxs = np.asarray(idxs)[valid_mask]
+
+        Vbj = self.statistics_["cov"][valid_idxs][:, valid_idxs]
+        coef = self.coef_[valid_idxs].copy()
+
+        # center spline term coefficients (smooth/intercept identifiability)
         if isinstance(self.terms[term_i], SplineTerm):
-            coef -= coef.mean()
+            coef = coef - coef.mean()
 
-        inv_cov, rank = sp.linalg.pinv(cov, return_rank=True)
-        score = coef.T.dot(inv_cov).dot(coef)
+        edf_j = float(edf1_arr[valid_idxs].sum())
+        edf_j = max(edf_j, 1e-6)
 
-        # compute p-values
         if self.distribution._known_scale:
-            # for known scale use chi-squared statistic
-            return 1 - sp.stats.chi2.cdf(x=score, df=rank)
+            res_df = -1
         else:
-            # if scale has been estimated, prefer to use f-statistic
-            score = score / rank
-            return 1 - sp.stats.f.cdf(
-                score, rank, self.statistics_["n_samples"] - self.statistics_["edof"]
-            )
+            res_df = self.statistics_["n_samples"] - self.statistics_["edof"]
+
+        _, pval, _ = self._woodteststat(coef, Vbj, edf_j, res_df)
+        return pval
 
     def confidence_intervals(self, X, width=0.95, quantiles=None):
         """Estimate confidence intervals for the model.

--- a/pygam/tests/test_GAM_methods.py
+++ b/pygam/tests/test_GAM_methods.py
@@ -511,7 +511,12 @@ class TestRegressions:
         gamA = LinearGAM(s(0) + s(1) + f(2)).fit(X, y * 1000000)
         gamB = LinearGAM(s(0) + s(1) + f(2)).fit(X, y)
 
-        assert np.allclose(gamA.statistics_["p_values"], gamB.statistics_["p_values"])
+        assert np.allclose(
+            gamA.statistics_["p_values"],
+            gamB.statistics_["p_values"],
+            atol=1e-6,
+            equal_nan=True,
+        )
 
     def test_2d_y_still_allow_fitting_in_PoissonGAM(self, coal_X_y):
         """

--- a/pygam/tests/test_pvalues.py
+++ b/pygam/tests/test_pvalues.py
@@ -39,6 +39,7 @@ def wood_weights(k_int_part, nu):
 
 # --- Category A: closed-form standard cases ---
 
+
 @pytest.mark.parametrize("x", [0.5, 1.0, 2.71, 3.84, 6.63, 10.83])
 def test_liu2_single_chi2_1(gam, x):
     got = gam._liu2(x, [1.0])
@@ -62,12 +63,16 @@ def test_liu2_scaled_chi2(gam, x):
 
 # --- Category B: Wood-style fractional mixtures (vs Monte Carlo) ---
 
-@pytest.mark.parametrize("k_int,nu,xs", [
-    (3, 0.7, [2.0, 5.0, 7.5, 12.0]),
-    (2, 0.3, [1.5, 4.0, 7.0]),
-    (5, 0.9, [3.0, 8.0, 15.0]),
-    (1, 0.5, [0.5, 2.0, 4.5]),
-])
+
+@pytest.mark.parametrize(
+    "k_int,nu,xs",
+    [
+        (3, 0.7, [2.0, 5.0, 7.5, 12.0]),
+        (2, 0.3, [1.5, 4.0, 7.0]),
+        (5, 0.9, [3.0, 8.0, 15.0]),
+        (1, 0.5, [0.5, 2.0, 4.5]),
+    ],
+)
 def test_liu2_wood_mixtures(gam, k_int, nu, xs):
     val = wood_weights(k_int, nu)
     for x in xs:
@@ -77,6 +82,7 @@ def test_liu2_wood_mixtures(gam, k_int, nu, xs):
 
 
 # --- Category C: boundary x values ---
+
 
 def test_liu2_boundary(gam):
     lambdas = [1.0, 0.7, 0.4, 0.2]
@@ -89,6 +95,7 @@ def test_liu2_boundary(gam):
 
 # --- Category D: degenerate inputs ---
 
+
 def test_liu2_degenerate(gam):
     assert gam._liu2(1.0, []) == 1.0
     assert abs(gam._liu2(3.84, [1.0]) - 0.05) <= 0.005
@@ -98,6 +105,7 @@ def test_liu2_degenerate(gam):
 
 
 # --- Category E: stress / extreme parameters ---
+
 
 @pytest.mark.parametrize("x", [1.0, 10.0, 30.0])
 def test_liu2_skewed(gam, x):
@@ -124,6 +132,7 @@ def test_liu2_bimodal(gam, x):
 
 
 # --- Category F: internal consistency ---
+
 
 def test_liu2_monotonic(gam):
     lambdas = [1.0, 0.5, 0.3]
@@ -154,6 +163,7 @@ def test_liu2_permutation_invariance(gam):
 
 
 # --- Category G: scaled quadrature (estimated-scale case) ---
+
 
 @pytest.mark.parametrize("k0", [5, 20, 50, 100])
 def test_quadrature_f_1_k0(gam, k0):
@@ -189,13 +199,17 @@ def test_quadrature_converges_to_plain(gam):
 
 # --- Category H: heavy Monte Carlo ---
 
-@pytest.mark.parametrize("lambdas,xs", [
-    ([1.0, 0.5, 0.3, 0.1], [0.5, 1.5, 3.0, 6.0, 10.0]),
-    ([2.0, 1.5, 1.0, 0.5, 0.2], [1.0, 4.0, 8.0, 14.0]),
-    (wood_weights(3, 0.7), [2.0, 5.0, 8.0, 15.0]),
-    (wood_weights(5, 0.2), [3.0, 7.0, 12.0, 20.0]),
-    ([0.95, 0.92, 0.88, 0.85, 0.5, 0.3, 0.1], [1.0, 3.0, 6.0, 10.0]),
-])
+
+@pytest.mark.parametrize(
+    "lambdas,xs",
+    [
+        ([1.0, 0.5, 0.3, 0.1], [0.5, 1.5, 3.0, 6.0, 10.0]),
+        ([2.0, 1.5, 1.0, 0.5, 0.2], [1.0, 4.0, 8.0, 14.0]),
+        (wood_weights(3, 0.7), [2.0, 5.0, 8.0, 15.0]),
+        (wood_weights(5, 0.2), [3.0, 7.0, 12.0, 20.0]),
+        ([0.95, 0.92, 0.88, 0.85, 0.5, 0.3, 0.1], [1.0, 3.0, 6.0, 10.0]),
+    ],
+)
 def test_liu2_monte_carlo(gam, lambdas, xs):
     for x in xs:
         got = gam._liu2(x, lambdas)
@@ -206,6 +220,7 @@ def test_liu2_monte_carlo(gam, lambdas, xs):
 
 # --- Category I: random configurations ---
 
+
 def test_liu2_random_configs(gam):
     rng = np.random.default_rng(2024)
     for trial in range(15):
@@ -215,3 +230,176 @@ def test_liu2_random_configs(gam):
         got = gam._liu2(x, lambdas)
         expected = mc_pvalue(lambdas, x, seed=trial + 200)
         assert abs(got - expected) <= 0.03
+
+
+"""Tests for Wood (2013) p-value helper function (_woodteststat)."""
+
+
+def make_test_Vbj(eigenvalues, seed=0):
+    """Build a q x q covariance with the given eigenvalues (random directions)."""
+    eigenvalues = np.asarray(eigenvalues, dtype=float)
+    q = len(eigenvalues)
+    rng = np.random.default_rng(seed)
+    A = rng.standard_normal((q, q))
+    Q, _ = np.linalg.qr(A)
+    return Q @ np.diag(eigenvalues) @ Q.T
+
+
+def mc_woodteststat_pvalue(gam, Vbj, edf_j, T_obs, n_sim=20_000, seed=0):
+    """Monte-Carlo p-value: simulate beta ~ N(0, Vbj), count T_sim > T_obs."""
+    rng = np.random.default_rng(seed)
+    q = Vbj.shape[0]
+    L = np.linalg.cholesky(Vbj + 1e-12 * np.eye(q))
+    count = 0
+    for _ in range(n_sim):
+        beta = L @ rng.standard_normal(q)
+        T_sim, _, _ = gam._woodteststat(beta, Vbj, edf_j)
+        if T_sim > T_obs:
+            count += 1
+    return count / n_sim
+
+
+# --- Category J: Stage A,B,C structural invariants ---
+
+
+def test_woodteststat_returns_three_floats(gam):
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
+    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+    T, p, r = gam._woodteststat(coef, Vbj, 3.7)
+    assert isinstance(T, float) and isinstance(p, float) and isinstance(r, int)
+
+
+def test_woodteststat_pval_in_unit_interval(gam):
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
+    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+    _, p, _ = gam._woodteststat(coef, Vbj, 3.7)
+    assert 0.0 <= p <= 1.0
+
+
+def test_woodteststat_degenerate_Vbj_returns_pval_one(gam):
+    # all-zero covariance: term is effectively zero, p must be 1
+    Vbj = np.zeros((6, 6))
+    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+    T, p, r = gam._woodteststat(coef, Vbj, 3.7)
+    assert T == 0.0
+    assert p == 1.0
+    assert r == 1
+
+
+def test_woodteststat_near_zero_Vbj_returns_pval_one(gam):
+    # all eigenvalues 1e-20: still degenerate
+    Vbj = make_test_Vbj([1e-20] * 6)
+    coef = np.ones(6)
+    _, p, _ = gam._woodteststat(coef, Vbj, 3.7)
+    assert p == 1.0
+
+
+def test_woodteststat_deterministic(gam):
+    # same inputs -> same outputs
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=7)
+    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+    a = gam._woodteststat(coef, Vbj, 3.7)
+    b = gam._woodteststat(coef, Vbj, 3.7)
+    assert a == b
+
+
+# --- Category K: branch coverage ---
+
+
+@pytest.mark.parametrize("tau", [3.7, 2.3, 5.9, 1.5, 0.5])
+def test_woodteststat_fractional_branch(gam, tau):
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
+    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+    _, p, _ = gam._woodteststat(coef, Vbj, tau)
+    assert 0.0 <= p <= 1.0
+
+
+@pytest.mark.parametrize("tau", [1.0, 2.0, 3.0, 4.0, 5.0])
+def test_woodteststat_integer_branch(gam, tau):
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
+    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+    _, p, _ = gam._woodteststat(coef, Vbj, tau)
+    assert 0.0 <= p <= 1.0
+
+
+def test_woodteststat_stage_c_clamps_rank_deficient(gam):
+    # only 2 real directions exist, tau=3.7 asks for k1=4 -> must clamp
+    Vbj = make_test_Vbj([5.0, 3.0, 1e-18, 1e-18, 1e-18, 1e-18])
+    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+    _, p, r = gam._woodteststat(coef, Vbj, 3.7)
+    assert 0.0 <= p <= 1.0
+    assert r <= 2
+
+
+# --- Category L: signal vs noise behaviour ---
+
+
+def test_woodteststat_big_coef_significant(gam):
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
+    coef = np.array([10.0, 8.0, 6.0, 4.0, 2.0, 1.0])
+    _, p, _ = gam._woodteststat(coef, Vbj, 3.7)
+    assert p < 0.05
+
+
+def test_woodteststat_tiny_coef_not_significant(gam):
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
+    coef = np.full(6, 0.01)
+    _, p, _ = gam._woodteststat(coef, Vbj, 3.7)
+    assert p > 0.9
+
+
+def test_woodteststat_zero_coef_pval_one(gam):
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
+    coef = np.zeros(6)
+    T, p, _ = gam._woodteststat(coef, Vbj, 3.7)
+    assert T == 0.0
+    assert p == 1.0
+
+
+# --- Category M: scale-known vs scale-estimated ---
+
+
+def test_woodteststat_estimated_scale_runs(gam):
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
+    coef = np.array([2.0, 1.5, -1.0, 0.8, 0.3, -0.2])
+    _, p, _ = gam._woodteststat(coef, Vbj, 3.7, res_df=80)
+    assert 0.0 <= p <= 1.0
+
+
+def test_woodteststat_estimated_scale_no_smaller_than_known(gam):
+    # estimating the scale adds uncertainty -> p should be >= the known-scale one
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
+    coef = np.array([3.0, 2.0, -1.5, 1.0, 0.5, -0.3])
+    _, p_known, _ = gam._woodteststat(coef, Vbj, 3.7)
+    _, p_est, _ = gam._woodteststat(coef, Vbj, 3.7, res_df=30)
+    assert p_est >= p_known - 1e-9
+
+
+@pytest.mark.parametrize("res_df", [10, 50, 200])
+def test_woodteststat_integer_estimated_uses_F(gam, res_df):
+    # integer tau, estimated scale -> F distribution path
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
+    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+    _, p, _ = gam._woodteststat(coef, Vbj, 4.0, res_df=res_df)
+    assert 0.0 <= p <= 1.0
+
+
+# --- Category N: Monte Carlo validation (statistical correctness) ---
+
+
+@pytest.mark.parametrize("tau,beta_seed", [(3.7, 4), (2.3, 0), (5.5, 2)])
+def test_woodteststat_matches_monte_carlo_fractional(gam, tau, beta_seed):
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
+    rng = np.random.default_rng(beta_seed + 1000)
+    beta = np.linalg.cholesky(Vbj + 1e-12 * np.eye(6)) @ rng.standard_normal(6)
+    T, p, _ = gam._woodteststat(beta, Vbj, tau)
+    mc = mc_woodteststat_pvalue(gam, Vbj, tau, T, n_sim=30_000, seed=beta_seed + 5000)
+    assert abs(p - mc) < 0.05
+
+
+def test_woodteststat_matches_monte_carlo_integer(gam):
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=3)
+    beta = np.array([1.5, 1.0, -0.8, 0.5, 0.2, -0.1])
+    T, p, _ = gam._woodteststat(beta, Vbj, 4.0)
+    mc = mc_woodteststat_pvalue(gam, Vbj, 4.0, T, n_sim=30_000, seed=4)
+    assert abs(p - mc) < 0.05

--- a/pygam/tests/test_pvalues.py
+++ b/pygam/tests/test_pvalues.py
@@ -686,9 +686,7 @@ def test_tensor_power_and_null():
         r = np.random.default_rng(i)
         x0 = r.uniform(0, 1, 300)
         x1 = r.uniform(0, 1, 300)
-        z_sig = np.sin(2 * np.pi * x0) * np.cos(
-            2 * np.pi * x1
-        ) + 0.3 * r.standard_normal(300)
+        z_sig = np.sin(2 * np.pi * x0) * np.cos(2 * np.pi * x1) + 0.3 * r.standard_normal(300)
         z_null = r.standard_normal(300)
         X = np.column_stack([x0, x1])
         p_sig.append(LinearGAM(te(0, 1)).fit(X, z_sig).statistics_["p_values"][0])
@@ -708,31 +706,10 @@ def test_tensor_in_mixed_model():
         x0 = r.uniform(0, 1, 300)
         x1 = r.uniform(0, 1, 300)
         x2 = r.uniform(0, 1, 300)
-        y = np.sin(2 * np.pi * x1) * np.cos(2 * np.pi * x2) + 0.3 * r.standard_normal(
-            300
-        )
-        pv = (
-            LinearGAM(s(0) + te(1, 2))
-            .fit(np.column_stack([x0, x1, x2]), y)
-            .statistics_["p_values"]
-        )
+        y = np.sin(2 * np.pi * x1) * np.cos(2 * np.pi * x2) + 0.3 * r.standard_normal(300)
+        pv = LinearGAM(s(0) + te(1, 2)).fit(np.column_stack([x0, x1, x2]), y).statistics_["p_values"]
         fire_te += pv[1] < 0.05
         fire_s += pv[0] < 0.05
     assert fire_te / N > 0.9
     assert fire_s / N < 0.25
 
-
-# ==========================================================================
-# P. real dataset: smooth + factor terms recover known truth.  SLOW.
-# ==========================================================================
-@pytest.mark.slow
-def test_wage_dataset_recovers_known_effects():
-    """ISLR wage data: s(year) weak-but-real, s(age) strong, f(education) strong.
-    Exercises the FACTOR-term p-value path end-to-end on real data."""
-    X, y = wage(return_X_y=True)
-    g = LinearGAM(s(0) + s(1) + f(2)).fit(X, y)
-    p_year, p_age, p_edu, p_int = g.statistics_["p_values"]
-    assert p_age < 0.05  # age strongly nonlinear
-    assert p_edu < 0.05  # education (factor) strong
-    assert p_year < 0.05  # year weak but present
-    assert np.isnan(p_int)  # intercept: no test

--- a/pygam/tests/test_pvalues.py
+++ b/pygam/tests/test_pvalues.py
@@ -29,7 +29,7 @@ import numpy as np
 import pytest
 from scipy import stats
 
-from pygam import LinearGAM, LogisticGAM, s, f, te
+from pygam import LinearGAM, LogisticGAM, f, s, te
 from pygam.datasets import mcycle, wage
 
 
@@ -127,9 +127,9 @@ def test_liu2_wood_mixtures(gam, k_int, nu, xs):
 @pytest.mark.parametrize(
     "lambdas",
     [
-        [10.0] + [0.01] * 20,          # highly skewed
+        [10.0] + [0.01] * 20,  # highly skewed
         [np.exp(-i * 0.3) for i in range(15)],  # exponential decay
-        [100.0, 0.01],                  # bimodal
+        [100.0, 0.01],  # bimodal
         [0.95, 0.92, 0.88, 0.5, 0.3, 0.1],
     ],
 )
@@ -197,25 +197,38 @@ def test_liu2_permutation_invariance(gam):
 @pytest.mark.parametrize("k0", [5, 50, 100])
 def test_quadrature_matches_F_single(gam, k0):
     d = 4.0
-    assert abs(gam._liu2_scaled_quadrature(d, [1.0], k0) - float(stats.f.sf(d, 1, k0))) <= 0.02
+    assert (
+        abs(gam._liu2_scaled_quadrature(d, [1.0], k0) - float(stats.f.sf(d, 1, k0)))
+        <= 0.02
+    )
 
 
 @pytest.mark.parametrize(("k", "k0"), [(3, 30), (8, 50)])
 def test_quadrature_matches_F_multi(gam, k, k0):
     d = 6.0
-    assert abs(
-        gam._liu2_scaled_quadrature(d, [1.0] * k, k0) - float(stats.f.sf(d / k, k, k0))
-    ) <= 0.025
+    assert (
+        abs(
+            gam._liu2_scaled_quadrature(d, [1.0] * k, k0)
+            - float(stats.f.sf(d / k, k, k0))
+        )
+        <= 0.025
+    )
 
 
 def test_quadrature_wood_mixture_vs_mc(gam):
     val = wood_weights(3, 0.4)
-    assert abs(gam._liu2_scaled_quadrature(5.0, val, 20) - mc_scaled(5.0, val, 20, seed=9)) <= 0.03
+    assert (
+        abs(gam._liu2_scaled_quadrature(5.0, val, 20) - mc_scaled(5.0, val, 20, seed=9))
+        <= 0.03
+    )
 
 
 def test_quadrature_converges_to_plain_as_k0_grows(gam):
     val = wood_weights(2, 0.5)
-    assert abs(gam._liu2_scaled_quadrature(4.0, val, k0=10_000) - gam._liu2(4.0, val)) <= 0.005
+    assert (
+        abs(gam._liu2_scaled_quadrature(4.0, val, k0=10_000) - gam._liu2(4.0, val))
+        <= 0.005
+    )
 
 
 # ==========================================================================
@@ -276,7 +289,9 @@ def test_woodteststat_clamps_rank_deficient(gam):
 # ==========================================================================
 def test_woodteststat_big_coef_significant(gam):
     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
-    _, p, _ = gam._woodteststat(np.array([10.0, 8.0, 6.0, 4.0, 2.0, 1.0]), Vbj, 3.7, make_Xj(6))
+    _, p, _ = gam._woodteststat(
+        np.array([10.0, 8.0, 6.0, 4.0, 2.0, 1.0]), Vbj, 3.7, make_Xj(6)
+    )
     assert p < 0.05
 
 
@@ -319,7 +334,8 @@ def mc_woodteststat_pvalue(gam, Vbj, edf_j, T_obs, Xj, n_sim=20_000, seed=0):
     rng = np.random.default_rng(seed)
     L = np.linalg.cholesky(Vbj + 1e-12 * np.eye(Vbj.shape[0]))
     count = sum(
-        gam._woodteststat(L @ rng.standard_normal(Vbj.shape[0]), Vbj, edf_j, Xj)[0] > T_obs
+        gam._woodteststat(L @ rng.standard_normal(Vbj.shape[0]), Vbj, edf_j, Xj)[0]
+        > T_obs
         for _ in range(n_sim)
     )
     return count / n_sim
@@ -332,7 +348,9 @@ def test_woodteststat_matches_monte_carlo(gam, tau, beta_seed):
     rng = np.random.default_rng(beta_seed + 1000)
     beta = np.linalg.cholesky(Vbj + 1e-12 * np.eye(6)) @ rng.standard_normal(6)
     T, p, _ = gam._woodteststat(beta, Vbj, tau, Xj)
-    mc = mc_woodteststat_pvalue(gam, Vbj, tau, T, Xj, n_sim=30_000, seed=beta_seed + 5000)
+    mc = mc_woodteststat_pvalue(
+        gam, Vbj, tau, T, Xj, n_sim=30_000, seed=beta_seed + 5000
+    )
     assert abs(p - mc) < 0.05
 
 
@@ -388,21 +406,83 @@ def _mgcv_case(specs, master_seed, name):
 
 _SPECS_B1 = [
     ("c1_frac_known", (20, 4), [4.0, 2.0, 1.0, 0.5], 1, [1.0, -0.5, 0.8, 0.3], 2.7, -1),
-    ("c2_frac_estscale", (30, 5), [5.0, 3.0, 2.0, 1.0, 0.4], 2, [2.0, 1.0, -0.7, 0.5, 0.2], 3.4, 25),
+    (
+        "c2_frac_estscale",
+        (30, 5),
+        [5.0, 3.0, 2.0, 1.0, 0.4],
+        2,
+        [2.0, 1.0, -0.7, 0.5, 0.2],
+        3.4,
+        25,
+    ),
     ("c3_int_full", (25, 4), [3.0, 2.0, 1.0, 0.5], 3, [1.5, -1.0, 0.6, 0.2], 4.0, -1),
-    ("c4_int_trunc", (40, 6), [6.0, 4.0, 3.0, 2.0, 1.0, 0.5], 4, [1.0, -0.5, 0.8, 0.3, -0.2, 0.1], 4.0, -1),
-    ("c5_frac_big", (100, 8), [8.0, 6.0, 5.0, 3.0, 2.0, 1.0, 0.6, 0.3], 5,
-     [1.2, -0.8, 1.0, 0.5, -0.3, 0.4, 0.1, -0.05], 5.6, -1),
+    (
+        "c4_int_trunc",
+        (40, 6),
+        [6.0, 4.0, 3.0, 2.0, 1.0, 0.5],
+        4,
+        [1.0, -0.5, 0.8, 0.3, -0.2, 0.1],
+        4.0,
+        -1,
+    ),
+    (
+        "c5_frac_big",
+        (100, 8),
+        [8.0, 6.0, 5.0, 3.0, 2.0, 1.0, 0.6, 0.3],
+        5,
+        [1.2, -0.8, 1.0, 0.5, -0.3, 0.4, 0.1, -0.05],
+        5.6,
+        -1,
+    ),
     ("c6_frac_estscale_sm", (15, 3), [3.0, 1.5, 0.7], 6, [1.0, 0.5, -0.3], 1.8, 12),
 ]
 _SPECS_B2 = [
-    ("b2_nu_tiny", (30, 5), [5.0, 3.0, 2.0, 1.0, 0.5], 10, [1.0, -0.5, 0.8, 0.3, -0.2], 3.05, -1),
-    ("b2_nu_big", (30, 5), [5.0, 3.0, 2.0, 1.0, 0.5], 11, [1.0, -0.5, 0.8, 0.3, -0.2], 3.95, -1),
+    (
+        "b2_nu_tiny",
+        (30, 5),
+        [5.0, 3.0, 2.0, 1.0, 0.5],
+        10,
+        [1.0, -0.5, 0.8, 0.3, -0.2],
+        3.05,
+        -1,
+    ),
+    (
+        "b2_nu_big",
+        (30, 5),
+        [5.0, 3.0, 2.0, 1.0, 0.5],
+        11,
+        [1.0, -0.5, 0.8, 0.3, -0.2],
+        3.95,
+        -1,
+    ),
     ("b2_k_equals_1", (20, 3), [4.0, 1.5, 0.6], 12, [1.2, 0.4, -0.7], 1.4, -1),
-    ("b2_big_q", (150, 9), [9.0, 7.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.5, 0.2], 13,
-     [1.0, -0.8, 0.6, 0.5, -0.4, 0.3, -0.2, 0.1, 0.05], 6.3, -1),
-    ("b2_small_resdf", (20, 4), [4.0, 2.0, 1.0, 0.5], 14, [1.5, -0.6, 0.9, 0.3], 2.6, 5),
-    ("b2_strong_signal", (40, 5), [5.0, 3.0, 2.0, 1.0, 0.4], 15, [6.0, 4.0, -3.0, 2.5, 1.5], 3.4, -1),
+    (
+        "b2_big_q",
+        (150, 9),
+        [9.0, 7.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.5, 0.2],
+        13,
+        [1.0, -0.8, 0.6, 0.5, -0.4, 0.3, -0.2, 0.1, 0.05],
+        6.3,
+        -1,
+    ),
+    (
+        "b2_small_resdf",
+        (20, 4),
+        [4.0, 2.0, 1.0, 0.5],
+        14,
+        [1.5, -0.6, 0.9, 0.3],
+        2.6,
+        5,
+    ),
+    (
+        "b2_strong_signal",
+        (40, 5),
+        [5.0, 3.0, 2.0, 1.0, 0.4],
+        15,
+        [6.0, 4.0, -3.0, 2.5, 1.5],
+        3.4,
+        -1,
+    ),
 ]
 # (stat, pval) from mgcv 1.8-41 mgcv:::testStat
 MGCV_REFERENCE = {
@@ -456,10 +536,10 @@ def _null_pvalues(term_factory, family, n_sims, n, seed=0):
         d = 1 if family == "uni" else 2
         X = rng.uniform(0.0, 1.0, size=(n, d))
         if "logit" in family:
-            y = rng.integers(0, 2, size=n)          # Bernoulli(0.5), independent of X
+            y = rng.integers(0, 2, size=n)  # Bernoulli(0.5), independent of X
             g = LogisticGAM(term_factory())
         else:
-            y = rng.standard_normal(n)              # noise, independent of X
+            y = rng.standard_normal(n)  # noise, independent of X
             g = LinearGAM(term_factory())
         try:
             g.fit(X if d > 1 else X[:, 0], y)
@@ -475,7 +555,7 @@ def _null_pvalues(term_factory, family, n_sims, n, seed=0):
 def test_null_calibration_gaussian_univariate():
     pv = _null_pvalues(lambda: s(0), "uni", n_sims=150, n=150, seed=0)
     assert 0.40 < pv.mean() < 0.60
-    assert (pv < 0.05).mean() < 0.12                 # not anti-conservative (the bug)
+    assert (pv < 0.05).mean() < 0.12  # not anti-conservative (the bug)
     assert stats.kstest(pv, "uniform").pvalue > 0.01  # not distinguishable from uniform
 
 
@@ -515,20 +595,25 @@ def test_discrimination_signal_vs_decoy():
     p_sig, p_dec = [], []
     for _ in range(40):
         x = rng.uniform(0.0, 1.0, 300)
-        y = rng.uniform(0.0, 1.0, 300)                # decoy: never enters z
+        y = rng.uniform(0.0, 1.0, 300)  # decoy: never enters z
         z = np.sin(2.0 * np.pi * x) + 0.5 * rng.standard_normal(300)
-        pv = LinearGAM(s(0) + s(1)).fit(np.column_stack([x, y]), z).statistics_["p_values"]
+        pv = (
+            LinearGAM(s(0) + s(1))
+            .fit(np.column_stack([x, y]), z)
+            .statistics_["p_values"]
+        )
         p_sig.append(pv[0])
         p_dec.append(pv[1])
     p_sig, p_dec = np.asarray(p_sig), np.asarray(p_dec)
-    assert (p_sig < 0.05).mean() > 0.9                # signal detected
-    assert (p_dec < 0.05).mean() < 0.25               # decoy not over-flagged
-    assert p_dec.mean() > 0.25                        # decoy roughly uniform
+    assert (p_sig < 0.05).mean() > 0.9  # signal detected
+    assert (p_dec < 0.05).mean() < 0.25  # decoy not over-flagged
+    assert p_dec.mean() > 0.25  # decoy roughly uniform
 
 
 @pytest.mark.slow
 def test_amplitude_dose_response():
     """Median p(s(x)) must fall as the true signal amplitude grows."""
+
     def median_p(amp):
         rng = np.random.default_rng(100)
         ps = []
@@ -539,8 +624,8 @@ def test_amplitude_dose_response():
         return float(np.median(ps))
 
     meds = [median_p(a) for a in (0.0, 0.25, 1.0)]
-    assert meds[0] > meds[1] > meds[2]                # monotone decreasing
-    assert meds[2] < 1e-3                              # strong signal -> tiny p
+    assert meds[0] > meds[1] > meds[2]  # monotone decreasing
+    assert meds[2] < 1e-3  # strong signal -> tiny p
 
 
 # ==========================================================================
@@ -601,7 +686,9 @@ def test_tensor_power_and_null():
         r = np.random.default_rng(i)
         x0 = r.uniform(0, 1, 300)
         x1 = r.uniform(0, 1, 300)
-        z_sig = np.sin(2 * np.pi * x0) * np.cos(2 * np.pi * x1) + 0.3 * r.standard_normal(300)
+        z_sig = np.sin(2 * np.pi * x0) * np.cos(
+            2 * np.pi * x1
+        ) + 0.3 * r.standard_normal(300)
         z_null = r.standard_normal(300)
         X = np.column_stack([x0, x1])
         p_sig.append(LinearGAM(te(0, 1)).fit(X, z_sig).statistics_["p_values"][0])
@@ -621,10 +708,31 @@ def test_tensor_in_mixed_model():
         x0 = r.uniform(0, 1, 300)
         x1 = r.uniform(0, 1, 300)
         x2 = r.uniform(0, 1, 300)
-        y = np.sin(2 * np.pi * x1) * np.cos(2 * np.pi * x2) + 0.3 * r.standard_normal(300)
-        pv = LinearGAM(s(0) + te(1, 2)).fit(np.column_stack([x0, x1, x2]), y).statistics_["p_values"]
+        y = np.sin(2 * np.pi * x1) * np.cos(2 * np.pi * x2) + 0.3 * r.standard_normal(
+            300
+        )
+        pv = (
+            LinearGAM(s(0) + te(1, 2))
+            .fit(np.column_stack([x0, x1, x2]), y)
+            .statistics_["p_values"]
+        )
         fire_te += pv[1] < 0.05
         fire_s += pv[0] < 0.05
     assert fire_te / N > 0.9
     assert fire_s / N < 0.25
 
+
+# ==========================================================================
+# P. real dataset: smooth + factor terms recover known truth.  SLOW.
+# ==========================================================================
+@pytest.mark.slow
+def test_wage_dataset_recovers_known_effects():
+    """ISLR wage data: s(year) weak-but-real, s(age) strong, f(education) strong.
+    Exercises the FACTOR-term p-value path end-to-end on real data."""
+    X, y = wage(return_X_y=True)
+    g = LinearGAM(s(0) + s(1) + f(2)).fit(X, y)
+    p_year, p_age, p_edu, p_int = g.statistics_["p_values"]
+    assert p_age < 0.05  # age strongly nonlinear
+    assert p_edu < 0.05  # education (factor) strong
+    assert p_year < 0.05  # year weak but present
+    assert np.isnan(p_int)  # intercept: no test

--- a/pygam/tests/test_pvalues.py
+++ b/pygam/tests/test_pvalues.py
@@ -543,11 +543,12 @@ def _null_pvalues(term_factory, family, n_sims, n, seed=0):
             g = LinearGAM(term_factory())
         try:
             g.fit(X if d > 1 else X[:, 0], y)
-            p = g.statistics_["p_values"][0]
-            if np.isfinite(p):
-                out.append(float(p))
-        except Exception:
-            pass
+        except Exception as err:  # noqa: BLE001 - a non-converged null fit is skipped
+            _ = err
+            continue
+        p = g.statistics_["p_values"][0]
+        if np.isfinite(p):
+            out.append(float(p))
     return np.asarray(out)
 
 
@@ -680,13 +681,14 @@ def test_tensor_curve_space_eigenvalues_consistent():
 @pytest.mark.slow
 def test_tensor_power_and_null():
     """te(0,1) must fire on a real 2-D interaction and stay quiet on the null."""
-    rng = np.random.default_rng(0)
     p_sig, p_null = [], []
     for i in range(30):
         r = np.random.default_rng(i)
         x0 = r.uniform(0, 1, 300)
         x1 = r.uniform(0, 1, 300)
-        z_sig = np.sin(2 * np.pi * x0) * np.cos(2 * np.pi * x1) + 0.3 * r.standard_normal(300)
+        z_sig = np.sin(2 * np.pi * x0) * np.cos(
+            2 * np.pi * x1
+        ) + 0.3 * r.standard_normal(300)
         z_null = r.standard_normal(300)
         X = np.column_stack([x0, x1])
         p_sig.append(LinearGAM(te(0, 1)).fit(X, z_sig).statistics_["p_values"][0])
@@ -698,7 +700,6 @@ def test_tensor_power_and_null():
 @pytest.mark.slow
 def test_tensor_in_mixed_model():
     """s(0) + te(1,2) where only the tensor carries signal: tensor fires, decoy s(0) doesn't."""
-    rng = np.random.default_rng(0)
     fire_te, fire_s = 0, 0
     N = 30
     for i in range(N):
@@ -706,10 +707,31 @@ def test_tensor_in_mixed_model():
         x0 = r.uniform(0, 1, 300)
         x1 = r.uniform(0, 1, 300)
         x2 = r.uniform(0, 1, 300)
-        y = np.sin(2 * np.pi * x1) * np.cos(2 * np.pi * x2) + 0.3 * r.standard_normal(300)
-        pv = LinearGAM(s(0) + te(1, 2)).fit(np.column_stack([x0, x1, x2]), y).statistics_["p_values"]
+        y = np.sin(2 * np.pi * x1) * np.cos(2 * np.pi * x2) + 0.3 * r.standard_normal(
+            300
+        )
+        pv = (
+            LinearGAM(s(0) + te(1, 2))
+            .fit(np.column_stack([x0, x1, x2]), y)
+            .statistics_["p_values"]
+        )
         fire_te += pv[1] < 0.05
         fire_s += pv[0] < 0.05
     assert fire_te / N > 0.9
     assert fire_s / N < 0.25
 
+
+# ==========================================================================
+# P. real dataset: smooth + factor terms recover known truth.  SLOW.
+# ==========================================================================
+@pytest.mark.slow
+def test_wage_dataset_recovers_known_effects():
+    """ISLR wage data: s(year) weak-but-real, s(age) strong, f(education) strong.
+    Exercises the FACTOR-term p-value path end-to-end on real data."""
+    X, y = wage(return_X_y=True)
+    g = LinearGAM(s(0) + s(1) + f(2)).fit(X, y)
+    p_year, p_age, p_edu, p_int = g.statistics_["p_values"]
+    assert p_age < 0.05  # age strongly nonlinear
+    assert p_edu < 0.05  # education (factor) strong
+    assert p_year < 0.05  # year weak but present
+    assert np.isnan(p_int)  # intercept: no test

--- a/pygam/tests/test_pvalues.py
+++ b/pygam/tests/test_pvalues.py
@@ -2,9 +2,10 @@
 
 import numpy as np
 import pytest
+from scipy import stats
+
 from pygam import LinearGAM
 from pygam.datasets import mcycle
-from scipy import stats
 
 
 @pytest.fixture(scope="module")

--- a/pygam/tests/test_pvalues.py
+++ b/pygam/tests/test_pvalues.py
@@ -492,3 +492,53 @@ def test_null_calibration_gaussian_tensor():
     assert 0.35 < pv.mean() < 0.65
     assert (pv < 0.05).mean() < 0.15
 
+
+# ==========================================================================
+# N. end-to-end known-signal power and discrimination.  SLOW.
+# ==========================================================================
+@pytest.mark.slow
+def test_power_gaussian_signal_detected():
+    """A real smooth effect must be rejected essentially always."""
+    rng = np.random.default_rng(1)
+    pv = []
+    for _ in range(30):
+        x = rng.uniform(0.0, 1.0, 200)
+        y = np.sin(2.0 * np.pi * x) + 0.5 * rng.standard_normal(200)
+        pv.append(LinearGAM(s(0)).fit(x, y).statistics_["p_values"][0])
+    assert (np.asarray(pv) < 0.05).mean() > 0.9
+
+
+@pytest.mark.slow
+def test_discrimination_signal_vs_decoy():
+    """z = sin(x) + 0*y + noise : s(x) must fire, decoy s(y) must not."""
+    rng = np.random.default_rng(0)
+    p_sig, p_dec = [], []
+    for _ in range(40):
+        x = rng.uniform(0.0, 1.0, 300)
+        y = rng.uniform(0.0, 1.0, 300)                # decoy: never enters z
+        z = np.sin(2.0 * np.pi * x) + 0.5 * rng.standard_normal(300)
+        pv = LinearGAM(s(0) + s(1)).fit(np.column_stack([x, y]), z).statistics_["p_values"]
+        p_sig.append(pv[0])
+        p_dec.append(pv[1])
+    p_sig, p_dec = np.asarray(p_sig), np.asarray(p_dec)
+    assert (p_sig < 0.05).mean() > 0.9                # signal detected
+    assert (p_dec < 0.05).mean() < 0.25               # decoy not over-flagged
+    assert p_dec.mean() > 0.25                        # decoy roughly uniform
+
+
+@pytest.mark.slow
+def test_amplitude_dose_response():
+    """Median p(s(x)) must fall as the true signal amplitude grows."""
+    def median_p(amp):
+        rng = np.random.default_rng(100)
+        ps = []
+        for _ in range(20):
+            x = rng.uniform(0.0, 1.0, 300)
+            z = amp * np.sin(2.0 * np.pi * x) + 0.5 * rng.standard_normal(300)
+            ps.append(LinearGAM(s(0)).fit(x, z).statistics_["p_values"][0])
+        return float(np.median(ps))
+
+    meds = [median_p(a) for a in (0.0, 0.25, 1.0)]
+    assert meds[0] > meds[1] > meds[2]                # monotone decreasing
+    assert meds[2] < 1e-3                              # strong signal -> tiny p
+

--- a/pygam/tests/test_pvalues.py
+++ b/pygam/tests/test_pvalues.py
@@ -542,3 +542,89 @@ def test_amplitude_dose_response():
     assert meds[0] > meds[1] > meds[2]                # monotone decreasing
     assert meds[2] < 1e-3                              # strong signal -> tiny p
 
+
+# ==========================================================================
+# O. tensor / multidimensional terms
+# ==========================================================================
+def _extract_term(g, term_i):
+    idx = np.asarray(g.terms.get_coef_indices(term_i))
+    idx = idx[idx < len(g.statistics_["edf1_per_coef"])]
+    coef = g.coef_[idx]
+    Vbj = g.statistics_["cov"][np.ix_(idx, idx)]
+    Xj = np.asarray(g._modelmat_train_[:, idx].todense())
+    edf = float(g.statistics_["edf1_per_coef"][idx].sum())
+    return coef, Vbj, Xj, edf
+
+
+def test_tensor_statistic_matches_mgcv():
+    """A tensor term extracted from a real fit must match compiled mgcv.
+
+    Deterministic fit (seed 7, 5x5 basis); mgcv:::testStat on the same extracted
+    (X, V, coef, edf) returned stat = 30.080062, pval = 0.01624483689.
+    """
+    rng = np.random.default_rng(7)
+    n = 150
+    a0 = rng.uniform(0, 1, n)
+    a1 = rng.uniform(0, 1, n)
+    z = np.sin(2 * np.pi * a0) * np.cos(2 * np.pi * a1) + 0.3 * rng.standard_normal(n)
+    g = LinearGAM(te(0, 1, n_splines=5)).fit(np.column_stack([a0, a1]), z)
+    coef, Vbj, Xj, edf = _extract_term(g, 0)
+    T, p, _ = g._woodteststat(coef, Vbj, edf, Xj - Xj.mean(0), -1)
+    assert abs(T - 30.080062) < 1e-4
+    assert abs(p - 0.01624483689) < 0.02
+
+
+def test_tensor_curve_space_eigenvalues_consistent():
+    """mgcv-independent: eig(R Vbj R^T) must equal the nonzero eig of the curve
+    covariance Xc Vbj Xc^T for a real (rank-deficient) tensor basis."""
+    rng = np.random.default_rng(0)
+    n = 300
+    x0 = rng.uniform(0, 1, n)
+    x1 = rng.uniform(0, 1, n)
+    z = np.sin(2 * np.pi * x0) * np.cos(2 * np.pi * x1) + 0.3 * rng.standard_normal(n)
+    g = LinearGAM(te(0, 1)).fit(np.column_stack([x0, x1]), z)
+    _, Vbj, Xj, _ = _extract_term(g, 0)
+    Xc = Xj - Xj.mean(0)
+    _, R = np.linalg.qr(Xc)
+    eW = np.sort(np.linalg.eigvalsh((R @ Vbj @ R.T + (R @ Vbj @ R.T).T) / 2))[::-1]
+    Vf = (Xc @ Vbj @ Xc.T + (Xc @ Vbj @ Xc.T).T) / 2
+    eF = np.sort(np.linalg.eigvalsh(Vf))[::-1][: len(eW)]
+    assert np.allclose(eW, eF, atol=1e-8)
+
+
+@pytest.mark.slow
+def test_tensor_power_and_null():
+    """te(0,1) must fire on a real 2-D interaction and stay quiet on the null."""
+    rng = np.random.default_rng(0)
+    p_sig, p_null = [], []
+    for i in range(30):
+        r = np.random.default_rng(i)
+        x0 = r.uniform(0, 1, 300)
+        x1 = r.uniform(0, 1, 300)
+        z_sig = np.sin(2 * np.pi * x0) * np.cos(2 * np.pi * x1) + 0.3 * r.standard_normal(300)
+        z_null = r.standard_normal(300)
+        X = np.column_stack([x0, x1])
+        p_sig.append(LinearGAM(te(0, 1)).fit(X, z_sig).statistics_["p_values"][0])
+        p_null.append(LinearGAM(te(0, 1)).fit(X, z_null).statistics_["p_values"][0])
+    assert (np.asarray(p_sig) < 0.05).mean() > 0.9
+    assert 0.30 < np.asarray(p_null).mean() < 0.70
+
+
+@pytest.mark.slow
+def test_tensor_in_mixed_model():
+    """s(0) + te(1,2) where only the tensor carries signal: tensor fires, decoy s(0) doesn't."""
+    rng = np.random.default_rng(0)
+    fire_te, fire_s = 0, 0
+    N = 30
+    for i in range(N):
+        r = np.random.default_rng(1000 + i)
+        x0 = r.uniform(0, 1, 300)
+        x1 = r.uniform(0, 1, 300)
+        x2 = r.uniform(0, 1, 300)
+        y = np.sin(2 * np.pi * x1) * np.cos(2 * np.pi * x2) + 0.3 * r.standard_normal(300)
+        pv = LinearGAM(s(0) + te(1, 2)).fit(np.column_stack([x0, x1, x2]), y).statistics_["p_values"]
+        fire_te += pv[1] < 0.05
+        fire_s += pv[0] < 0.05
+    assert fire_te / N > 0.9
+    assert fire_s / N < 0.25
+

--- a/pygam/tests/test_pvalues.py
+++ b/pygam/tests/test_pvalues.py
@@ -1,28 +1,57 @@
-"""Tests for Wood (2013) p-value helper functions (liu2)."""
+"""Tests for the Wood (2013) smooth-term p-values in pyGAM (issue #163).
+
+Layered from cheap unit checks up to real-data validation:
+
+  liu2 reference distribution
+    A  closed-form limits (single/equal/scaled chi-squared)
+    B  Wood fractional mixtures vs Monte Carlo
+    C  boundary and degenerate inputs
+    D  mathematical invariants (monotone, permutation, scale)
+    E  estimated-scale quadrature
+
+  _woodteststat statistic
+    F  structural invariants / degenerate guards
+    G  branch coverage (fractional / integer / rank-deficient)
+    H  signal-vs-noise behaviour
+    I  scale known vs estimated
+    J  Monte-Carlo correctness
+    K  curve-space rotation (dropped-R regression guards)
+    L  numeric match to compiled mgcv 1.8-41 testStat (12 cases)
+
+  end-to-end (real fits, marked slow)
+    M  null calibration (type-I error is Uniform[0,1])
+    N  known-signal power and discrimination
+    O  tensor / multidimensional terms (incl. mgcv match)
+    P  real dataset: smooth + factor terms recover known truth
+"""
 
 import numpy as np
 import pytest
 from scipy import stats
 
-from pygam import LinearGAM
-from pygam.datasets import mcycle
+from pygam import LinearGAM, LogisticGAM, s, f, te
+from pygam.datasets import mcycle, wage
 
 
 @pytest.fixture(scope="module")
 def gam():
-    """A fitted GAM instance, so we can call its _liu2 methods."""
+    """A fitted GAM, so we can call its _liu2 / _woodteststat helpers."""
     X, y = mcycle(return_X_y=True)
     return LinearGAM().fit(X, y)
 
 
-def mc_pvalue(lambdas, x, n_samples=300_000, seed=0):
+# --------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------
+def mc_pvalue(lambdas, x, n_samples=200_000, seed=0):
+    """Monte-Carlo P(sum lambda_i chi2_1 > x)."""
     rng = np.random.default_rng(seed)
     lam = np.asarray(lambdas, dtype=float)
     samples = rng.chisquare(1.0, size=(n_samples, len(lam))) @ lam
     return float((samples > x).mean())
 
 
-def mc_scaled(d, val, k0, n_samples=300_000, seed=0):
+def mc_scaled(d, val, k0, n_samples=200_000, seed=0):
     rng = np.random.default_rng(seed)
     val = np.asarray(val, dtype=float)
     Q = rng.chisquare(1.0, size=(n_samples, len(val))) @ val
@@ -31,69 +60,103 @@ def mc_scaled(d, val, k0, n_samples=300_000, seed=0):
 
 
 def wood_weights(k_int_part, nu):
+    """The reference-distribution weights [1,...,1, nu1, nu2] for a term."""
     rp = nu + 1.0
     nu1 = (rp + np.sqrt(rp * (2.0 - rp))) / 2.0
-    nu2 = rp - nu1
-    return [1.0] * (k_int_part - 1) + [nu1, nu2]
+    return [1.0] * (k_int_part - 1) + [nu1, rp - nu1]
 
 
-# --- Category A: closed-form standard cases ---
+def make_test_Vbj(eigenvalues, seed=0):
+    """q x q covariance with the given eigenvalues along random directions."""
+    ev = np.asarray(eigenvalues, dtype=float)
+    q = len(ev)
+    rng = np.random.default_rng(seed)
+    Q, _ = np.linalg.qr(rng.standard_normal((q, q)))
+    return Q @ np.diag(ev) @ Q.T
 
 
-@pytest.mark.parametrize("x", [0.5, 1.0, 2.71, 3.84, 6.63, 10.83])
+def make_Xj(q):
+    """Model matrix whose column-centred form is orthonormal, so qr(Xj) gives
+    R = I and _woodteststat operates directly on the supplied Vbj."""
+    n = q + 1
+    rng = np.random.default_rng(12345)
+    M = np.column_stack([np.ones(n), rng.standard_normal((n, q))])
+    Q, _ = np.linalg.qr(M)
+    return Q[:, 1 : q + 1]
+
+
+# ==========================================================================
+# A. liu2 -- closed-form limits
+# ==========================================================================
+@pytest.mark.parametrize("x", [0.5, 2.71, 3.84, 10.83])
 def test_liu2_single_chi2_1(gam, x):
-    got = gam._liu2(x, [1.0])
-    expected = float(stats.chi2.sf(x, df=1))
-    assert abs(got - expected) <= 0.03
+    assert abs(gam._liu2(x, [1.0]) - float(stats.chi2.sf(x, df=1))) <= 0.03
 
 
-@pytest.mark.parametrize("k", [2, 3, 5, 10])
-def test_liu2_equal_weights_chi2_k(gam, k):
+@pytest.mark.parametrize("k", [2, 5, 10, 50])
+def test_liu2_equal_weights_is_chi2_k(gam, k):
+    # sum of k unit-weight chi2_1 == chi2_k; 95th pct must give ~0.05
     x = float(stats.chi2.ppf(0.95, df=k))
-    got = gam._liu2(x, [1.0] * k)
-    assert abs(got - 0.05) <= 0.02
+    assert abs(gam._liu2(x, [1.0] * k) - 0.05) <= 0.02
 
 
-@pytest.mark.parametrize("x", [2.0, 4.0, 8.0])
+@pytest.mark.parametrize("x", [2.0, 8.0])
 def test_liu2_scaled_chi2(gam, x):
-    got = gam._liu2(x, [2.0, 2.0])
-    expected = float(stats.chi2.sf(x / 2.0, df=2))
-    assert abs(got - expected) <= 0.02
+    assert abs(gam._liu2(x, [2.0, 2.0]) - float(stats.chi2.sf(x / 2.0, df=2))) <= 0.02
 
 
-# --- Category B: Wood-style fractional mixtures (vs Monte Carlo) ---
-
-
+# ==========================================================================
+# B. liu2 -- Wood fractional mixtures vs Monte Carlo (the real use case)
+# ==========================================================================
 @pytest.mark.parametrize(
     ("k_int", "nu", "xs"),
     [
-        (3, 0.7, [2.0, 5.0, 7.5, 12.0]),
-        (2, 0.3, [1.5, 4.0, 7.0]),
-        (5, 0.9, [3.0, 8.0, 15.0]),
-        (1, 0.5, [0.5, 2.0, 4.5]),
+        (3, 0.7, [2.0, 5.0, 12.0]),
+        (2, 0.3, [1.5, 7.0]),
+        (5, 0.9, [3.0, 15.0]),
+        (1, 0.5, [0.5, 4.5]),
     ],
 )
 def test_liu2_wood_mixtures(gam, k_int, nu, xs):
     val = wood_weights(k_int, nu)
     for x in xs:
-        got = gam._liu2(x, val)
-        expected = mc_pvalue(val, x, seed=int(k_int * 10 + nu * 100 + x))
-        assert abs(got - expected) <= 0.025
+        exp = mc_pvalue(val, x, seed=int(k_int * 10 + nu * 100 + x))
+        assert abs(gam._liu2(x, val) - exp) <= 0.03
 
 
-# --- Category C: boundary x values ---
+@pytest.mark.parametrize(
+    "lambdas",
+    [
+        [10.0] + [0.01] * 20,          # highly skewed
+        [np.exp(-i * 0.3) for i in range(15)],  # exponential decay
+        [100.0, 0.01],                  # bimodal
+        [0.95, 0.92, 0.88, 0.5, 0.3, 0.1],
+    ],
+)
+def test_liu2_diverse_configs_vs_mc(gam, lambdas):
+    for x in [1.0, 5.0, float(sum(lambdas))]:
+        exp = mc_pvalue(lambdas, x, seed=int(x * 7 + 11))
+        tol = 0.03 if exp > 0.01 else 0.015
+        assert abs(gam._liu2(x, lambdas) - exp) <= tol
 
 
-def test_liu2_boundary(gam):
-    lambdas = [1.0, 0.7, 0.4, 0.2]
-    assert abs(gam._liu2(0.0, lambdas) - 1.0) <= 0.05
-    assert abs(gam._liu2(-100.0, lambdas) - 1.0) <= 0.01
-    assert abs(gam._liu2(1000.0, lambdas) - 0.0) <= 0.01
-    muQ = sum(lambdas)
-    assert abs(gam._liu2(muQ, lambdas) - mc_pvalue(lambdas, muQ, seed=5)) <= 0.03
+def test_liu2_random_fuzz(gam):
+    rng = np.random.default_rng(2024)
+    for trial in range(8):
+        k = int(rng.integers(2, 12))
+        lam = rng.uniform(0.05, 3.0, size=k).tolist()
+        x = float(rng.uniform(0.5, sum(lam) * 2))
+        assert abs(gam._liu2(x, lam) - mc_pvalue(lam, x, seed=trial + 200)) <= 0.03
 
 
-# --- Category D: degenerate inputs ---
+# ==========================================================================
+# C. liu2 -- boundary and degenerate inputs
+# ==========================================================================
+def test_liu2_boundary_values(gam):
+    lam = [1.0, 0.7, 0.4, 0.2]
+    assert abs(gam._liu2(0.0, lam) - 1.0) <= 0.05
+    assert abs(gam._liu2(-100.0, lam) - 1.0) <= 0.01
+    assert abs(gam._liu2(1000.0, lam) - 0.0) <= 0.01
 
 
 def test_liu2_degenerate(gam):
@@ -104,231 +167,87 @@ def test_liu2_degenerate(gam):
     assert abs(gam._liu2(1.0, [1e-12] * 100) - 0.0) <= 0.01
 
 
-# --- Category E: stress / extreme parameters ---
-
-
-@pytest.mark.parametrize("x", [1.0, 10.0, 30.0])
-def test_liu2_skewed(gam, x):
-    lambdas = [10.0] + [0.01] * 20
-    assert abs(gam._liu2(x, lambdas) - mc_pvalue(lambdas, x, seed=6)) <= 0.03
-
-
-def test_liu2_high_dim(gam):
-    k = 50
-    x = float(stats.chi2.ppf(0.95, df=k))
-    assert abs(gam._liu2(x, [1.0] * k) - 0.05) <= 0.02
-
-
-@pytest.mark.parametrize("x", [0.5, 2.0, 5.0])
-def test_liu2_exp_decay(gam, x):
-    lambdas = [np.exp(-i * 0.3) for i in range(15)]
-    assert abs(gam._liu2(x, lambdas) - mc_pvalue(lambdas, x, seed=7)) <= 0.03
-
-
-@pytest.mark.parametrize("x", [50.0, 150.0, 500.0])
-def test_liu2_bimodal(gam, x):
-    lambdas = [100.0, 0.01]
-    assert abs(gam._liu2(x, lambdas) - mc_pvalue(lambdas, x, seed=8)) <= 0.03
-
-
-# --- Category F: internal consistency ---
-
-
-def test_liu2_monotonic(gam):
-    lambdas = [1.0, 0.5, 0.3]
-    xs = np.linspace(0.5, 10, 20)
-    pvals = [gam._liu2(x, lambdas) for x in xs]
-    assert all(pvals[i] >= pvals[i + 1] - 1e-9 for i in range(len(pvals) - 1))
-
-
-def test_liu2_in_range(gam):
-    xs = np.concatenate([np.linspace(-10, 0, 5), np.linspace(0.1, 50, 20)])
-    assert all(0 <= gam._liu2(x, [1.0, 0.7, 0.4, 0.2]) <= 1 for x in xs)
+# ==========================================================================
+# D. liu2 -- mathematical invariants
+# ==========================================================================
+def test_liu2_monotone_and_in_range(gam):
+    lam = [1.0, 0.5, 0.3]
+    xs = np.linspace(-5, 15, 40)
+    ps = [gam._liu2(x, lam) for x in xs]
+    assert all(0.0 <= p <= 1.0 for p in ps)
+    assert all(ps[i] >= ps[i + 1] - 1e-9 for i in range(len(ps) - 1))
 
 
 def test_liu2_scale_equivariance(gam):
-    lambdas = [1.0, 0.5, 0.2]
+    lam = [1.0, 0.5, 0.2]
     c = 4.7
-    got1 = gam._liu2(3.0, lambdas)
-    got2 = gam._liu2(c * 3.0, [c * l for l in lambdas])
-    assert abs(got1 - got2) <= 0.001
+    assert abs(gam._liu2(3.0, lam) - gam._liu2(c * 3.0, [c * l for l in lam])) <= 0.001
 
 
 def test_liu2_permutation_invariance(gam):
-    lambdas = [1.0, 0.5, 0.2, 0.05]
-    a = gam._liu2(2.5, lambdas)
-    b = gam._liu2(2.5, list(reversed(lambdas)))
-    c = gam._liu2(2.5, sorted(lambdas))
-    assert abs(a - b) < 1e-10 and abs(a - c) < 1e-10
+    lam = [1.0, 0.5, 0.2, 0.05]
+    a = gam._liu2(2.5, lam)
+    assert abs(a - gam._liu2(2.5, lam[::-1])) < 1e-10
+    assert abs(a - gam._liu2(2.5, sorted(lam))) < 1e-10
 
 
-# --- Category G: scaled quadrature (estimated-scale case) ---
-
-
-@pytest.mark.parametrize("k0", [5, 20, 50, 100])
-def test_quadrature_f_1_k0(gam, k0):
+# ==========================================================================
+# E. liu2 -- estimated-scale quadrature
+# ==========================================================================
+@pytest.mark.parametrize("k0", [5, 50, 100])
+def test_quadrature_matches_F_single(gam, k0):
     d = 4.0
-    got = gam._liu2_scaled_quadrature(d, [1.0], k0)
-    expected = float(stats.f.sf(d, dfn=1, dfd=k0))
-    assert abs(got - expected) <= 0.02
+    assert abs(gam._liu2_scaled_quadrature(d, [1.0], k0) - float(stats.f.sf(d, 1, k0))) <= 0.02
 
 
-@pytest.mark.parametrize(("k", "k0"), [(3, 30), (5, 100), (8, 50)])
-def test_quadrature_f_k_k0(gam, k, k0):
+@pytest.mark.parametrize(("k", "k0"), [(3, 30), (8, 50)])
+def test_quadrature_matches_F_multi(gam, k, k0):
     d = 6.0
-    got = gam._liu2_scaled_quadrature(d, [1.0] * k, k0)
-    expected = float(stats.f.sf(d / k, dfn=k, dfd=k0))
-    assert abs(got - expected) <= 0.025
+    assert abs(
+        gam._liu2_scaled_quadrature(d, [1.0] * k, k0) - float(stats.f.sf(d / k, k, k0))
+    ) <= 0.025
 
 
-@pytest.mark.parametrize("k0", [20, 100])
-def test_quadrature_wood_mixture(gam, k0):
+def test_quadrature_wood_mixture_vs_mc(gam):
     val = wood_weights(3, 0.4)
-    d = 5.0
-    got = gam._liu2_scaled_quadrature(d, val, k0)
-    expected = mc_scaled(d, val, k0, seed=9)
-    assert abs(got - expected) <= 0.03
+    assert abs(gam._liu2_scaled_quadrature(5.0, val, 20) - mc_scaled(5.0, val, 20, seed=9)) <= 0.03
 
 
-def test_quadrature_converges_to_plain(gam):
+def test_quadrature_converges_to_plain_as_k0_grows(gam):
     val = wood_weights(2, 0.5)
-    plain = gam._liu2(4.0, val)
-    scaled = gam._liu2_scaled_quadrature(4.0, val, k0=10_000)
-    assert abs(scaled - plain) <= 0.005
+    assert abs(gam._liu2_scaled_quadrature(4.0, val, k0=10_000) - gam._liu2(4.0, val)) <= 0.005
 
 
-# --- Category H: heavy Monte Carlo ---
-
-
-@pytest.mark.parametrize(
-    ("lambdas", "xs"),
-    [
-        ([1.0, 0.5, 0.3, 0.1], [0.5, 1.5, 3.0, 6.0, 10.0]),
-        ([2.0, 1.5, 1.0, 0.5, 0.2], [1.0, 4.0, 8.0, 14.0]),
-        (wood_weights(3, 0.7), [2.0, 5.0, 8.0, 15.0]),
-        (wood_weights(5, 0.2), [3.0, 7.0, 12.0, 20.0]),
-        ([0.95, 0.92, 0.88, 0.85, 0.5, 0.3, 0.1], [1.0, 3.0, 6.0, 10.0]),
-    ],
-)
-def test_liu2_monte_carlo(gam, lambdas, xs):
-    for x in xs:
-        got = gam._liu2(x, lambdas)
-        expected = mc_pvalue(lambdas, x, n_samples=300_000, seed=int(x * 7 + 11))
-        tol = 0.025 if expected > 0.01 else 0.01
-        assert abs(got - expected) <= tol
-
-
-# --- Category I: random configurations ---
-
-
-def test_liu2_random_configs(gam):
-    rng = np.random.default_rng(2024)
-    for trial in range(15):
-        k = int(rng.integers(2, 12))
-        lambdas = rng.uniform(0.05, 3.0, size=k).tolist()
-        x = float(rng.uniform(0.5, sum(lambdas) * 2))
-        got = gam._liu2(x, lambdas)
-        expected = mc_pvalue(lambdas, x, seed=trial + 200)
-        assert abs(got - expected) <= 0.03
-
-
-# =====================================================================
-# Tests for Wood (2013) test statistic (_woodteststat)
-# =====================================================================
-# _woodteststat now takes the term's model matrix Xj and computes the
-# statistic in curve space. make_Xj builds an Xj whose column-centered
-# form is orthonormal, so qr(Xj) gives R = I and the statistic is
-# computed directly on the supplied Vbj (no rotation). This lets each
-# unit test specify, via Vbj, exactly the matrix to eigendecompose.
-
-
-def make_test_Vbj(eigenvalues, seed=0):
-    """Build a q x q covariance with the given eigenvalues (random directions)."""
-    eigenvalues = np.asarray(eigenvalues, dtype=float)
-    q = len(eigenvalues)
-    rng = np.random.default_rng(seed)
-    A = rng.standard_normal((q, q))
-    Q, _ = np.linalg.qr(A)
-    return Q @ np.diag(eigenvalues) @ Q.T
-
-
-def make_Xj(q):
-    """Model matrix whose column-centered form is orthonormal.
-
-    The columns are orthonormal and orthogonal to the constant vector, so
-    column-centering is a no-op and qr(Xj) yields R = I. The curve-space
-    transform W = R Vbj R^T then reduces to Vbj, so _woodteststat operates
-    directly on the supplied Vbj and coefficients.
-    """
-    n = q + 1
-    rng = np.random.default_rng(12345)
-    M = np.column_stack([np.ones(n), rng.standard_normal((n, q))])
-    Q, _ = np.linalg.qr(M)
-    return Q[:, 1 : q + 1]
-
-
-def mc_woodteststat_pvalue(gam, Vbj, edf_j, T_obs, Xj, n_sim=20_000, seed=0):
-    """Monte-Carlo p-value: simulate beta ~ N(0, Vbj), count T_sim > T_obs."""
-    rng = np.random.default_rng(seed)
-    q = Vbj.shape[0]
-    L = np.linalg.cholesky(Vbj + 1e-12 * np.eye(q))
-    count = 0
-    for _ in range(n_sim):
-        beta = L @ rng.standard_normal(q)
-        T_sim, _, _ = gam._woodteststat(beta, Vbj, edf_j, Xj)
-        if T_sim > T_obs:
-            count += 1
-    return count / n_sim
-
-
-# --- Category J: Stage A,B,C structural invariants ---
-
-
-def test_woodteststat_returns_three_floats(gam):
+# ==========================================================================
+# F. _woodteststat -- structural invariants / degenerate guards
+# ==========================================================================
+def test_woodteststat_returns_three_typed_values(gam):
     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
     coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
     T, p, r = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6))
     assert isinstance(T, float) and isinstance(p, float) and isinstance(r, int)
-
-
-def test_woodteststat_pval_in_unit_interval(gam):
-    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
-    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
-    _, p, _ = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6))
     assert 0.0 <= p <= 1.0
 
 
-def test_woodteststat_degenerate_Vbj_returns_pval_one(gam):
-    # all-zero covariance: term is effectively zero, p must be 1
-    Vbj = np.zeros((6, 6))
-    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
-    T, p, r = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6))
-    assert T == 0.0
-    assert p == 1.0
-    assert r == 1
-
-
-def test_woodteststat_near_zero_Vbj_returns_pval_one(gam):
-    # all eigenvalues 1e-20: still degenerate
-    Vbj = make_test_Vbj([1e-20] * 6)
-    coef = np.ones(6)
-    _, p, _ = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6))
-    assert p == 1.0
-
-
 def test_woodteststat_deterministic(gam):
-    # same inputs -> same outputs
     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=7)
     coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
-    a = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6))
-    b = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6))
-    assert a == b
+    assert gam._woodteststat(coef, Vbj, 3.7, make_Xj(6)) == gam._woodteststat(
+        coef, Vbj, 3.7, make_Xj(6)
+    )
 
 
-# --- Category K: branch coverage ---
+def test_woodteststat_degenerate_Vbj_gives_pval_one(gam):
+    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+    for Vbj in (np.zeros((6, 6)), make_test_Vbj([1e-20] * 6)):
+        T, p, r = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6))
+        assert p == 1.0
 
 
-@pytest.mark.parametrize("tau", [3.7, 2.3, 5.9, 1.5, 0.5])
+# ==========================================================================
+# G. _woodteststat -- branch coverage
+# ==========================================================================
+@pytest.mark.parametrize("tau", [0.5, 1.5, 2.3, 3.7, 5.9])
 def test_woodteststat_fractional_branch(gam, tau):
     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
     coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
@@ -336,7 +255,7 @@ def test_woodteststat_fractional_branch(gam, tau):
     assert 0.0 <= p <= 1.0
 
 
-@pytest.mark.parametrize("tau", [1.0, 2.0, 3.0, 4.0, 5.0])
+@pytest.mark.parametrize("tau", [1.0, 3.0, 5.0])
 def test_woodteststat_integer_branch(gam, tau):
     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
     coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
@@ -344,52 +263,40 @@ def test_woodteststat_integer_branch(gam, tau):
     assert 0.0 <= p <= 1.0
 
 
-def test_woodteststat_stage_c_clamps_rank_deficient(gam):
-    # only 2 real directions exist, tau=3.7 asks for k1=4 -> must clamp
+def test_woodteststat_clamps_rank_deficient(gam):
+    # only 2 real directions; tau=3.7 asks for 4 -> must clamp the rank
     Vbj = make_test_Vbj([5.0, 3.0, 1e-18, 1e-18, 1e-18, 1e-18])
     coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
     _, p, r = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6))
-    assert 0.0 <= p <= 1.0
-    assert r <= 2
+    assert 0.0 <= p <= 1.0 and r <= 2
 
 
-# --- Category L: signal vs noise behaviour ---
-
-
+# ==========================================================================
+# H. _woodteststat -- signal vs noise
+# ==========================================================================
 def test_woodteststat_big_coef_significant(gam):
     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
-    coef = np.array([10.0, 8.0, 6.0, 4.0, 2.0, 1.0])
-    _, p, _ = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6))
+    _, p, _ = gam._woodteststat(np.array([10.0, 8.0, 6.0, 4.0, 2.0, 1.0]), Vbj, 3.7, make_Xj(6))
     assert p < 0.05
 
 
 def test_woodteststat_tiny_coef_not_significant(gam):
     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
-    coef = np.full(6, 0.01)
-    _, p, _ = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6))
+    _, p, _ = gam._woodteststat(np.full(6, 0.01), Vbj, 3.7, make_Xj(6))
     assert p > 0.9
 
 
-def test_woodteststat_zero_coef_pval_one(gam):
+def test_woodteststat_zero_coef_gives_pval_one(gam):
     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
-    coef = np.zeros(6)
-    T, p, _ = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6))
-    assert T == 0.0
-    assert p == 1.0
+    T, p, _ = gam._woodteststat(np.zeros(6), Vbj, 3.7, make_Xj(6))
+    assert T == 0.0 and p == 1.0
 
 
-# --- Category M: scale-known vs scale-estimated ---
-
-
-def test_woodteststat_estimated_scale_runs(gam):
-    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
-    coef = np.array([2.0, 1.5, -1.0, 0.8, 0.3, -0.2])
-    _, p, _ = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6), res_df=80)
-    assert 0.0 <= p <= 1.0
-
-
+# ==========================================================================
+# I. _woodteststat -- scale known vs estimated
+# ==========================================================================
 def test_woodteststat_estimated_scale_no_smaller_than_known(gam):
-    # estimating the scale adds uncertainty -> p should be >= the known-scale one
+    # estimating the scale adds uncertainty -> p must be >= the known-scale p
     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
     coef = np.array([3.0, 2.0, -1.5, 1.0, 0.5, -0.3])
     _, p_known, _ = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6))
@@ -397,167 +304,77 @@ def test_woodteststat_estimated_scale_no_smaller_than_known(gam):
     assert p_est >= p_known - 1e-9
 
 
-@pytest.mark.parametrize("res_df", [10, 50, 200])
+@pytest.mark.parametrize("res_df", [10, 200])
 def test_woodteststat_integer_estimated_uses_F(gam, res_df):
-    # integer tau, estimated scale -> F distribution path
     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
     coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
     _, p, _ = gam._woodteststat(coef, Vbj, 4.0, make_Xj(6), res_df=res_df)
     assert 0.0 <= p <= 1.0
 
 
-# --- Category N: Monte Carlo validation (statistical correctness) ---
+# ==========================================================================
+# J. _woodteststat -- Monte-Carlo correctness
+# ==========================================================================
+def mc_woodteststat_pvalue(gam, Vbj, edf_j, T_obs, Xj, n_sim=20_000, seed=0):
+    rng = np.random.default_rng(seed)
+    L = np.linalg.cholesky(Vbj + 1e-12 * np.eye(Vbj.shape[0]))
+    count = sum(
+        gam._woodteststat(L @ rng.standard_normal(Vbj.shape[0]), Vbj, edf_j, Xj)[0] > T_obs
+        for _ in range(n_sim)
+    )
+    return count / n_sim
 
 
-@pytest.mark.parametrize(("tau", "beta_seed"), [(3.7, 4), (2.3, 0), (5.5, 2)])
-def test_woodteststat_matches_monte_carlo_fractional(gam, tau, beta_seed):
+@pytest.mark.parametrize(("tau", "beta_seed"), [(3.7, 4), (2.3, 0)])
+def test_woodteststat_matches_monte_carlo(gam, tau, beta_seed):
     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
     Xj = make_Xj(6)
     rng = np.random.default_rng(beta_seed + 1000)
     beta = np.linalg.cholesky(Vbj + 1e-12 * np.eye(6)) @ rng.standard_normal(6)
     T, p, _ = gam._woodteststat(beta, Vbj, tau, Xj)
-    mc = mc_woodteststat_pvalue(
-        gam, Vbj, tau, T, Xj, n_sim=30_000, seed=beta_seed + 5000
-    )
+    mc = mc_woodteststat_pvalue(gam, Vbj, tau, T, Xj, n_sim=30_000, seed=beta_seed + 5000)
     assert abs(p - mc) < 0.05
 
 
-def test_woodteststat_matches_monte_carlo_integer(gam):
-    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=3)
-    Xj = make_Xj(6)
-    beta = np.array([1.5, 1.0, -0.8, 0.5, 0.2, -0.1])
-    T, p, _ = gam._woodteststat(beta, Vbj, 4.0, Xj)
-    mc = mc_woodteststat_pvalue(gam, Vbj, 4.0, T, Xj, n_sim=30_000, seed=4)
-    assert abs(p - mc) < 0.05
-
-
-# --- Category O: real (non-orthonormal) basis exercises the curve-space path ---
-
-
-def test_woodteststat_uses_R_rotation_real_basis(gam):
-    """Regression test for the dropped-R bug.
-
-    The statistic is defined in curve space: it must rotate Vbj and coef by R
-    from qr(Xj), i.e. eigendecompose W = R Vbj R^T, not Vbj directly. With a
-    real (non-orthonormal) basis the rotation changes the answer, so a real Xj
-    must give a different statistic than the no-rotation (R = I) case obtained
-    from make_Xj. If R were dropped (Vbj eigendecomposed directly, ignoring Xj)
-    the two would be identical and this test would fail.
-
-    This only manifests at FRACTIONAL edf: at integer edf the full inverse is
-    basis-free, R cancels, and the curve-space and raw-Vbj statistics coincide.
-    """
-    rng = np.random.default_rng(0)
-    Xj_real = rng.standard_normal((100, 6))  # genuine basis -> R != I
-    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
-    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
-
-    T_real, _, _ = gam._woodteststat(coef, Vbj, 3.7, Xj_real)  # rotated (curve space)
-    T_identity, _, _ = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6))  # R = I -> raw Vbj
-
-    # the rotation must actually change the statistic
-    assert not np.isclose(T_real, T_identity, rtol=1e-3)
-
-
-def test_woodteststat_full_rank_edf_R_cancels(gam):
-    """Counterpart: only at FULL-RANK edf (tau == q, every direction inverted)
-    does the rotation cancel, so a real basis and the no-rotation case give the
-    same statistic (the full inverse is basis-free). At fractional or truncated
-    edf the rotation does not cancel - see the test above.
-    """
+# ==========================================================================
+# K. _woodteststat -- curve-space rotation (dropped-R regression guards)
+# ==========================================================================
+def test_woodteststat_rotates_by_R_at_fractional_edf(gam):
+    """Regression guard for the dropped-R bug: at fractional edf the statistic
+    must depend on the QR rotation of a real basis, so a genuine (non-orthonormal)
+    Xj gives a different T than the R = I case. If R were dropped they'd match."""
     rng = np.random.default_rng(0)
     Xj_real = rng.standard_normal((100, 6))
     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
     coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
-
-    # tau == q == 6: full inverse, basis-free
-    T_real, _, _ = gam._woodteststat(coef, Vbj, 6.0, Xj_real)
-    T_identity, _, _ = gam._woodteststat(coef, Vbj, 6.0, make_Xj(6))
-
-    assert np.isclose(T_real, T_identity, rtol=1e-6)
+    T_real, _, _ = gam._woodteststat(coef, Vbj, 3.7, Xj_real)
+    T_ident, _, _ = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6))
+    assert not np.isclose(T_real, T_ident, rtol=1e-3)
 
 
-def test_woodteststat_real_basis_valid_output(gam):
-    """A genuine non-orthonormal basis still returns a well-formed result."""
-    rng = np.random.default_rng(1)
-    Xj = rng.standard_normal((100, 6))
+def test_woodteststat_R_cancels_at_full_rank_edf(gam):
+    """Counterpart: at full-rank edf the full inverse is basis-free, so the
+    rotation cancels and a real basis matches the R = I case."""
+    rng = np.random.default_rng(0)
+    Xj_real = rng.standard_normal((100, 6))
     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
     coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
-    T, p, r = gam._woodteststat(coef, Vbj, 3.7, Xj)
-    assert T >= 0.0
-    assert 0.0 <= p <= 1.0
-    assert isinstance(r, int)
+    T_real, _, _ = gam._woodteststat(coef, Vbj, 6.0, Xj_real)
+    T_ident, _, _ = gam._woodteststat(coef, Vbj, 6.0, make_Xj(6))
+    assert np.isclose(T_real, T_ident, rtol=1e-6)
 
 
-# --- Category P: validation against compiled mgcv (mgcv 1.8-41 testStat) ---
-#
-# The reference stat/pval below were produced by running mgcv:::testStat on the
-# exact same inputs (real non-orthonormal bases, fractional and integer edf,
-# known and estimated scale). The bases are pre-centered so pyGAM's internal
-# column-centering is a no-op and both QR the identical matrix.
-#
-# The statistic matches mgcv to ~1e-9 across every case. The p-value matches
-# closely except a wider gap on the small-sample estimated-scale case (c6):
-# mgcv's psum.chisq uses Davies' method while pyGAM uses the Liu et al. (2009)
-# approximation, and the two disagree most in that tail. Hence stat is checked
+# ==========================================================================
+# L. _woodteststat -- numeric match to compiled mgcv 1.8-41 testStat
+# --------------------------------------------------------------------------
+# Reference (stat, pval) produced by mgcv:::testStat on the SAME pre-centred
+# inputs. The statistic matches to ~1e-9; the p-value matches within the
+# documented Davies (mgcv) vs Liu et al. 2009 (pyGAM) approximation gap, which
+# is widest in the small-sample estimated-scale tail. So stat is asserted
 # tightly and pval loosely.
-
-
-def _mgcv_case(name):
-    """Regenerate the exact (X, V, coef, edf, res_df) validated against mgcv.
-
-    PCG64 (np.random.default_rng) is version-stable, so these reproduce the
-    arrays mgcv:::testStat was evaluated on bit-for-bit.
-    """
-    specs = [
-        (
-            "c1_frac_known",
-            (20, 4),
-            [4.0, 2.0, 1.0, 0.5],
-            1,
-            [1.0, -0.5, 0.8, 0.3],
-            2.7,
-            -1,
-        ),
-        (
-            "c2_frac_estscale",
-            (30, 5),
-            [5.0, 3.0, 2.0, 1.0, 0.4],
-            2,
-            [2.0, 1.0, -0.7, 0.5, 0.2],
-            3.4,
-            25,
-        ),
-        (
-            "c3_int_full",
-            (25, 4),
-            [3.0, 2.0, 1.0, 0.5],
-            3,
-            [1.5, -1.0, 0.6, 0.2],
-            4.0,
-            -1,
-        ),
-        (
-            "c4_int_trunc",
-            (40, 6),
-            [6.0, 4.0, 3.0, 2.0, 1.0, 0.5],
-            4,
-            [1.0, -0.5, 0.8, 0.3, -0.2, 0.1],
-            4.0,
-            -1,
-        ),
-        (
-            "c5_frac_big",
-            (100, 8),
-            [8.0, 6.0, 5.0, 3.0, 2.0, 1.0, 0.6, 0.3],
-            5,
-            [1.2, -0.8, 1.0, 0.5, -0.3, 0.4, 0.1, -0.05],
-            5.6,
-            -1,
-        ),
-        ("c6_frac_estscale_sm", (15, 3), [3.0, 1.5, 0.7], 6, [1.0, 0.5, -0.3], 1.8, 12),
-    ]
-    rng = np.random.default_rng(100)
+# ==========================================================================
+def _mgcv_case(specs, master_seed, name):
+    rng = np.random.default_rng(master_seed)
     out = {}
     for nm, (n, q), ev, vseed, coef, edf, res_df in specs:
         X = rng.standard_normal((n, q))
@@ -569,6 +386,24 @@ def _mgcv_case(name):
     return out[name]
 
 
+_SPECS_B1 = [
+    ("c1_frac_known", (20, 4), [4.0, 2.0, 1.0, 0.5], 1, [1.0, -0.5, 0.8, 0.3], 2.7, -1),
+    ("c2_frac_estscale", (30, 5), [5.0, 3.0, 2.0, 1.0, 0.4], 2, [2.0, 1.0, -0.7, 0.5, 0.2], 3.4, 25),
+    ("c3_int_full", (25, 4), [3.0, 2.0, 1.0, 0.5], 3, [1.5, -1.0, 0.6, 0.2], 4.0, -1),
+    ("c4_int_trunc", (40, 6), [6.0, 4.0, 3.0, 2.0, 1.0, 0.5], 4, [1.0, -0.5, 0.8, 0.3, -0.2, 0.1], 4.0, -1),
+    ("c5_frac_big", (100, 8), [8.0, 6.0, 5.0, 3.0, 2.0, 1.0, 0.6, 0.3], 5,
+     [1.2, -0.8, 1.0, 0.5, -0.3, 0.4, 0.1, -0.05], 5.6, -1),
+    ("c6_frac_estscale_sm", (15, 3), [3.0, 1.5, 0.7], 6, [1.0, 0.5, -0.3], 1.8, 12),
+]
+_SPECS_B2 = [
+    ("b2_nu_tiny", (30, 5), [5.0, 3.0, 2.0, 1.0, 0.5], 10, [1.0, -0.5, 0.8, 0.3, -0.2], 3.05, -1),
+    ("b2_nu_big", (30, 5), [5.0, 3.0, 2.0, 1.0, 0.5], 11, [1.0, -0.5, 0.8, 0.3, -0.2], 3.95, -1),
+    ("b2_k_equals_1", (20, 3), [4.0, 1.5, 0.6], 12, [1.2, 0.4, -0.7], 1.4, -1),
+    ("b2_big_q", (150, 9), [9.0, 7.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.5, 0.2], 13,
+     [1.0, -0.8, 0.6, 0.5, -0.4, 0.3, -0.2, 0.1, 0.05], 6.3, -1),
+    ("b2_small_resdf", (20, 4), [4.0, 2.0, 1.0, 0.5], 14, [1.5, -0.6, 0.9, 0.3], 2.6, 5),
+    ("b2_strong_signal", (40, 5), [5.0, 3.0, 2.0, 1.0, 0.4], 15, [6.0, 4.0, -3.0, 2.5, 1.5], 3.4, -1),
+]
 # (stat, pval) from mgcv 1.8-41 mgcv:::testStat
 MGCV_REFERENCE = {
     "c1_frac_known": (1.018550885, 0.7881442045),
@@ -577,115 +412,6 @@ MGCV_REFERENCE = {
     "c4_int_trunc": (0.4571566394, 0.9775355139),
     "c5_frac_big": (0.9684885577, 0.9877958744),
     "c6_frac_estscale_sm": (0.109650584, 0.9185588708),
-}
-
-
-@pytest.mark.parametrize("case", list(MGCV_REFERENCE))
-def test_woodteststat_matches_mgcv_stat(gam, case):
-    """The test statistic must match compiled mgcv to high precision."""
-    X, V, coef, edf, res_df = _mgcv_case(case)
-    stat_mgcv, _ = MGCV_REFERENCE[case]
-    T, _, _ = gam._woodteststat(coef, V, edf, X, res_df)
-    assert abs(T - stat_mgcv) < 1e-6
-
-
-@pytest.mark.parametrize("case", list(MGCV_REFERENCE))
-def test_woodteststat_matches_mgcv_pval(gam, case):
-    """The p-value must match mgcv within the Davies-vs-Liu approximation gap."""
-    X, V, coef, edf, res_df = _mgcv_case(case)
-    _, pval_mgcv = MGCV_REFERENCE[case]
-    _, p, _ = gam._woodteststat(coef, V, edf, X, res_df)
-    assert abs(p - pval_mgcv) < 0.05
-
-
-# =====================================================================
-# Category P, batch 2: edge-case validation against compiled mgcv.
-#
-# Reference values from a manual run of mgcv 1.8-41 (see PR notes).
-#
-# Cases cover corners batch 1 missed:
-#   b2_nu_tiny       nu ~ 0.05  (barely-fractional boundary)
-#   b2_nu_big        nu ~ 0.95  (almost-integer boundary)
-#   b2_k_equals_1    tau = 1.4  (smallest fractional case, k = 1: no solid part)
-#   b2_big_q         q = 9, tau = 6.3 (larger basis)
-#   b2_small_resdf   res.df = 5 (tiny residual dof, quadrature stress)
-#   b2_strong_signal small-p tail (where liu2 vs Davies differs most)
-# =====================================================================
-
-
-def _mgcv_case_b2(name):
-    """Regenerate batch-2 inputs bit-for-bit (master seed 777, PCG64)."""
-    specs = [
-        (
-            "b2_nu_tiny",
-            (30, 5),
-            [5.0, 3.0, 2.0, 1.0, 0.5],
-            10,
-            [1.0, -0.5, 0.8, 0.3, -0.2],
-            3.05,
-            -1,
-        ),
-        (
-            "b2_nu_big",
-            (30, 5),
-            [5.0, 3.0, 2.0, 1.0, 0.5],
-            11,
-            [1.0, -0.5, 0.8, 0.3, -0.2],
-            3.95,
-            -1,
-        ),
-        ("b2_k_equals_1", (20, 3), [4.0, 1.5, 0.6], 12, [1.2, 0.4, -0.7], 1.4, -1),
-        (
-            "b2_big_q",
-            (150, 9),
-            [9.0, 7.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.5, 0.2],
-            13,
-            [1.0, -0.8, 0.6, 0.5, -0.4, 0.3, -0.2, 0.1, 0.05],
-            6.3,
-            -1,
-        ),
-        (
-            "b2_small_resdf",
-            (20, 4),
-            [4.0, 2.0, 1.0, 0.5],
-            14,
-            [1.5, -0.6, 0.9, 0.3],
-            2.6,
-            5,
-        ),
-        (
-            "b2_strong_signal",
-            (40, 5),
-            [5.0, 3.0, 2.0, 1.0, 0.4],
-            15,
-            [6.0, 4.0, -3.0, 2.5, 1.5],
-            3.4,
-            -1,
-        ),
-    ]
-    rng = np.random.default_rng(777)
-    out = {}
-    for nm, (n, q), ev, vseed, coef, edf, res_df in specs:
-        X = rng.standard_normal((n, q))
-        X = X - X.mean(axis=0)
-        vrng = np.random.default_rng(vseed)
-        Q, _ = np.linalg.qr(vrng.standard_normal((q, q)))
-        V = Q @ np.diag(np.asarray(ev, dtype=float)) @ Q.T
-        out[nm] = (X, V, np.array(coef), edf, res_df)
-    return out[name]
-
-
-# (stat, pval) from mgcv:::testStat — FILL FROM YOUR R RUN.
-# pyGAM's own predictions, for sanity while filling in
-# (stat should match mgcv to ~1e-9; pval within ~0.05):
-#   b2_nu_tiny        T=0.38402143   p=0.95503453
-#   b2_nu_big         T=0.85445653   p=0.94436587
-#   b2_k_equals_1     T=1.13614016   p=0.55520154
-#   b2_big_q          T=0.49344769   p=0.99951043
-#   b2_small_resdf    T=1.04390657   p=0.78477139
-#   b2_strong_signal  T=38.96929537  p=0.00335435
-# (stat, pval) from mgcv 1.8-41 mgcv:::testStat
-MGCV_REFERENCE_B2 = {
     "b2_nu_tiny": (0.3840214292, 0.9550042987),
     "b2_nu_big": (0.8544565278, 0.9431055405),
     "b2_k_equals_1": (1.136140158, 0.5668342894),
@@ -695,17 +421,74 @@ MGCV_REFERENCE_B2 = {
 }
 
 
-@pytest.mark.parametrize("case", list(MGCV_REFERENCE_B2))
-def test_woodteststat_matches_mgcv_stat_b2(gam, case):
-    X, V, coef, edf, res_df = _mgcv_case_b2(case)
-    stat_mgcv, _ = MGCV_REFERENCE_B2[case]
+def _lookup_mgcv_case(name):
+    if name.startswith("b2_"):
+        return _mgcv_case(_SPECS_B2, 777, name)
+    return _mgcv_case(_SPECS_B1, 100, name)
+
+
+@pytest.mark.parametrize("case", list(MGCV_REFERENCE))
+def test_woodteststat_matches_mgcv_stat(gam, case):
+    X, V, coef, edf, res_df = _lookup_mgcv_case(case)
+    stat_mgcv, _ = MGCV_REFERENCE[case]
     T, _, _ = gam._woodteststat(coef, V, edf, X, res_df)
     assert abs(T - stat_mgcv) < 1e-6
 
 
-@pytest.mark.parametrize("case", list(MGCV_REFERENCE_B2))
-def test_woodteststat_matches_mgcv_pval_b2(gam, case):
-    X, V, coef, edf, res_df = _mgcv_case_b2(case)
-    _, pval_mgcv = MGCV_REFERENCE_B2[case]
+@pytest.mark.parametrize("case", list(MGCV_REFERENCE))
+def test_woodteststat_matches_mgcv_pval(gam, case):
+    X, V, coef, edf, res_df = _lookup_mgcv_case(case)
+    _, pval_mgcv = MGCV_REFERENCE[case]
     _, p, _ = gam._woodteststat(coef, V, edf, X, res_df)
     assert abs(p - pval_mgcv) < 0.05
+
+
+# ==========================================================================
+# M. end-to-end null calibration (type-I error).  SLOW: fits many models.
+# --------------------------------------------------------------------------
+# Under the null (response independent of the covariate) a correct p-value is
+# Uniform[0, 1].  Issue #163's bug produced near-zero p-values on pure noise.
+# ==========================================================================
+def _null_pvalues(term_factory, family, n_sims, n, seed=0):
+    out = []
+    for i in range(n_sims):
+        rng = np.random.default_rng(seed + i)
+        d = 1 if family == "uni" else 2
+        X = rng.uniform(0.0, 1.0, size=(n, d))
+        if "logit" in family:
+            y = rng.integers(0, 2, size=n)          # Bernoulli(0.5), independent of X
+            g = LogisticGAM(term_factory())
+        else:
+            y = rng.standard_normal(n)              # noise, independent of X
+            g = LinearGAM(term_factory())
+        try:
+            g.fit(X if d > 1 else X[:, 0], y)
+            p = g.statistics_["p_values"][0]
+            if np.isfinite(p):
+                out.append(float(p))
+        except Exception:
+            pass
+    return np.asarray(out)
+
+
+@pytest.mark.slow
+def test_null_calibration_gaussian_univariate():
+    pv = _null_pvalues(lambda: s(0), "uni", n_sims=150, n=150, seed=0)
+    assert 0.40 < pv.mean() < 0.60
+    assert (pv < 0.05).mean() < 0.12                 # not anti-conservative (the bug)
+    assert stats.kstest(pv, "uniform").pvalue > 0.01  # not distinguishable from uniform
+
+
+@pytest.mark.slow
+def test_null_calibration_binary_univariate():
+    pv = _null_pvalues(lambda: s(0), "uni_logit", n_sims=150, n=200, seed=100)
+    assert 0.35 < pv.mean() < 0.65
+    assert (pv < 0.05).mean() < 0.15
+
+
+@pytest.mark.slow
+def test_null_calibration_gaussian_tensor():
+    pv = _null_pvalues(lambda: te(0, 1), "tensor", n_sims=120, n=200, seed=7)
+    assert 0.35 < pv.mean() < 0.65
+    assert (pv < 0.05).mean() < 0.15
+

--- a/pygam/tests/test_pvalues.py
+++ b/pygam/tests/test_pvalues.py
@@ -596,3 +596,116 @@ def test_woodteststat_matches_mgcv_pval(gam, case):
     _, pval_mgcv = MGCV_REFERENCE[case]
     _, p, _ = gam._woodteststat(coef, V, edf, X, res_df)
     assert abs(p - pval_mgcv) < 0.05
+
+
+# =====================================================================
+# Category P, batch 2: edge-case validation against compiled mgcv.
+#
+# Reference values from a manual run of mgcv 1.8-41 (see PR notes).
+#
+# Cases cover corners batch 1 missed:
+#   b2_nu_tiny       nu ~ 0.05  (barely-fractional boundary)
+#   b2_nu_big        nu ~ 0.95  (almost-integer boundary)
+#   b2_k_equals_1    tau = 1.4  (smallest fractional case, k = 1: no solid part)
+#   b2_big_q         q = 9, tau = 6.3 (larger basis)
+#   b2_small_resdf   res.df = 5 (tiny residual dof, quadrature stress)
+#   b2_strong_signal small-p tail (where liu2 vs Davies differs most)
+# =====================================================================
+
+
+def _mgcv_case_b2(name):
+    """Regenerate batch-2 inputs bit-for-bit (master seed 777, PCG64)."""
+    specs = [
+        (
+            "b2_nu_tiny",
+            (30, 5),
+            [5.0, 3.0, 2.0, 1.0, 0.5],
+            10,
+            [1.0, -0.5, 0.8, 0.3, -0.2],
+            3.05,
+            -1,
+        ),
+        (
+            "b2_nu_big",
+            (30, 5),
+            [5.0, 3.0, 2.0, 1.0, 0.5],
+            11,
+            [1.0, -0.5, 0.8, 0.3, -0.2],
+            3.95,
+            -1,
+        ),
+        ("b2_k_equals_1", (20, 3), [4.0, 1.5, 0.6], 12, [1.2, 0.4, -0.7], 1.4, -1),
+        (
+            "b2_big_q",
+            (150, 9),
+            [9.0, 7.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.5, 0.2],
+            13,
+            [1.0, -0.8, 0.6, 0.5, -0.4, 0.3, -0.2, 0.1, 0.05],
+            6.3,
+            -1,
+        ),
+        (
+            "b2_small_resdf",
+            (20, 4),
+            [4.0, 2.0, 1.0, 0.5],
+            14,
+            [1.5, -0.6, 0.9, 0.3],
+            2.6,
+            5,
+        ),
+        (
+            "b2_strong_signal",
+            (40, 5),
+            [5.0, 3.0, 2.0, 1.0, 0.4],
+            15,
+            [6.0, 4.0, -3.0, 2.5, 1.5],
+            3.4,
+            -1,
+        ),
+    ]
+    rng = np.random.default_rng(777)
+    out = {}
+    for nm, (n, q), ev, vseed, coef, edf, res_df in specs:
+        X = rng.standard_normal((n, q))
+        X = X - X.mean(axis=0)
+        vrng = np.random.default_rng(vseed)
+        Q, _ = np.linalg.qr(vrng.standard_normal((q, q)))
+        V = Q @ np.diag(np.asarray(ev, dtype=float)) @ Q.T
+        out[nm] = (X, V, np.array(coef), edf, res_df)
+    return out[name]
+
+
+# (stat, pval) from mgcv:::testStat — FILL FROM YOUR R RUN.
+# pyGAM's own predictions, for sanity while filling in
+# (stat should match mgcv to ~1e-9; pval within ~0.05):
+#   b2_nu_tiny        T=0.38402143   p=0.95503453
+#   b2_nu_big         T=0.85445653   p=0.94436587
+#   b2_k_equals_1     T=1.13614016   p=0.55520154
+#   b2_big_q          T=0.49344769   p=0.99951043
+#   b2_small_resdf    T=1.04390657   p=0.78477139
+#   b2_strong_signal  T=38.96929537  p=0.00335435
+# (stat, pval) from mgcv 1.8-41 mgcv:::testStat
+MGCV_REFERENCE_B2 = {
+    "b2_nu_tiny": (0.3840214292, 0.9550042987),
+    "b2_nu_big": (0.8544565278, 0.9431055405),
+    "b2_k_equals_1": (1.136140158, 0.5668342894),
+    "b2_big_q": (0.4934476887, 0.9992533887),
+    "b2_small_resdf": (1.04390657, 0.7821102297),
+    "b2_strong_signal": (38.96929537, 0.003368798371),
+}
+
+
+@pytest.mark.parametrize("case", list(MGCV_REFERENCE_B2))
+def test_woodteststat_matches_mgcv_stat_b2(gam, case):
+    X, V, coef, edf, res_df = _mgcv_case_b2(case)
+    stat_mgcv, _ = MGCV_REFERENCE_B2[case]
+    T, _, _ = gam._woodteststat(coef, V, edf, X, res_df)
+    assert abs(T - stat_mgcv) < 1e-6
+
+
+@pytest.mark.parametrize("case", list(MGCV_REFERENCE_B2))
+def test_woodteststat_matches_mgcv_pval_b2(gam, case):
+    X, V, coef, edf, res_df = _mgcv_case_b2(case)
+    _, pval_mgcv = MGCV_REFERENCE_B2[case]
+    _, p, _ = gam._woodteststat(coef, V, edf, X, res_df)
+    assert abs(p - pval_mgcv) < 0.05

--- a/pygam/tests/test_pvalues.py
+++ b/pygam/tests/test_pvalues.py
@@ -232,174 +232,176 @@ def test_liu2_random_configs(gam):
         assert abs(got - expected) <= 0.03
 
 
-"""Tests for Wood (2013) p-value helper function (_woodteststat)."""
+""" NEW TEST CASES UNDER PROGRESS FOR QR MODIFIED WOOD TEST STATISTIC FUNCTION"""
+
+# """Tests for Wood (2013) p-value helper function (_woodteststat)."""
 
 
-def make_test_Vbj(eigenvalues, seed=0):
-    """Build a q x q covariance with the given eigenvalues (random directions)."""
-    eigenvalues = np.asarray(eigenvalues, dtype=float)
-    q = len(eigenvalues)
-    rng = np.random.default_rng(seed)
-    A = rng.standard_normal((q, q))
-    Q, _ = np.linalg.qr(A)
-    return Q @ np.diag(eigenvalues) @ Q.T
+# def make_test_Vbj(eigenvalues, seed=0):
+#     """Build a q x q covariance with the given eigenvalues (random directions)."""
+#     eigenvalues = np.asarray(eigenvalues, dtype=float)
+#     q = len(eigenvalues)
+#     rng = np.random.default_rng(seed)
+#     A = rng.standard_normal((q, q))
+#     Q, _ = np.linalg.qr(A)
+#     return Q @ np.diag(eigenvalues) @ Q.T
 
 
-def mc_woodteststat_pvalue(gam, Vbj, edf_j, T_obs, n_sim=20_000, seed=0):
-    """Monte-Carlo p-value: simulate beta ~ N(0, Vbj), count T_sim > T_obs."""
-    rng = np.random.default_rng(seed)
-    q = Vbj.shape[0]
-    L = np.linalg.cholesky(Vbj + 1e-12 * np.eye(q))
-    count = 0
-    for _ in range(n_sim):
-        beta = L @ rng.standard_normal(q)
-        T_sim, _, _ = gam._woodteststat(beta, Vbj, edf_j)
-        if T_sim > T_obs:
-            count += 1
-    return count / n_sim
+# def mc_woodteststat_pvalue(gam, Vbj, edf_j, T_obs, n_sim=20_000, seed=0):
+#     """Monte-Carlo p-value: simulate beta ~ N(0, Vbj), count T_sim > T_obs."""
+#     rng = np.random.default_rng(seed)
+#     q = Vbj.shape[0]
+#     L = np.linalg.cholesky(Vbj + 1e-12 * np.eye(q))
+#     count = 0
+#     for _ in range(n_sim):
+#         beta = L @ rng.standard_normal(q)
+#         T_sim, _, _ = gam._woodteststat(beta, Vbj, edf_j)
+#         if T_sim > T_obs:
+#             count += 1
+#     return count / n_sim
 
 
-# --- Category J: Stage A,B,C structural invariants ---
+# # --- Category J: Stage A,B,C structural invariants ---
 
 
-def test_woodteststat_returns_three_floats(gam):
-    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
-    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
-    T, p, r = gam._woodteststat(coef, Vbj, 3.7)
-    assert isinstance(T, float) and isinstance(p, float) and isinstance(r, int)
+# def test_woodteststat_returns_three_floats(gam):
+#     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
+#     coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+#     T, p, r = gam._woodteststat(coef, Vbj, 3.7)
+#     assert isinstance(T, float) and isinstance(p, float) and isinstance(r, int)
 
 
-def test_woodteststat_pval_in_unit_interval(gam):
-    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
-    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
-    _, p, _ = gam._woodteststat(coef, Vbj, 3.7)
-    assert 0.0 <= p <= 1.0
+# def test_woodteststat_pval_in_unit_interval(gam):
+#     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
+#     coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+#     _, p, _ = gam._woodteststat(coef, Vbj, 3.7)
+#     assert 0.0 <= p <= 1.0
 
 
-def test_woodteststat_degenerate_Vbj_returns_pval_one(gam):
-    # all-zero covariance: term is effectively zero, p must be 1
-    Vbj = np.zeros((6, 6))
-    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
-    T, p, r = gam._woodteststat(coef, Vbj, 3.7)
-    assert T == 0.0
-    assert p == 1.0
-    assert r == 1
+# def test_woodteststat_degenerate_Vbj_returns_pval_one(gam):
+#     # all-zero covariance: term is effectively zero, p must be 1
+#     Vbj = np.zeros((6, 6))
+#     coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+#     T, p, r = gam._woodteststat(coef, Vbj, 3.7)
+#     assert T == 0.0
+#     assert p == 1.0
+#     assert r == 1
 
 
-def test_woodteststat_near_zero_Vbj_returns_pval_one(gam):
-    # all eigenvalues 1e-20: still degenerate
-    Vbj = make_test_Vbj([1e-20] * 6)
-    coef = np.ones(6)
-    _, p, _ = gam._woodteststat(coef, Vbj, 3.7)
-    assert p == 1.0
+# def test_woodteststat_near_zero_Vbj_returns_pval_one(gam):
+#     # all eigenvalues 1e-20: still degenerate
+#     Vbj = make_test_Vbj([1e-20] * 6)
+#     coef = np.ones(6)
+#     _, p, _ = gam._woodteststat(coef, Vbj, 3.7)
+#     assert p == 1.0
 
 
-def test_woodteststat_deterministic(gam):
-    # same inputs -> same outputs
-    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=7)
-    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
-    a = gam._woodteststat(coef, Vbj, 3.7)
-    b = gam._woodteststat(coef, Vbj, 3.7)
-    assert a == b
+# def test_woodteststat_deterministic(gam):
+#     # same inputs -> same outputs
+#     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=7)
+#     coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+#     a = gam._woodteststat(coef, Vbj, 3.7)
+#     b = gam._woodteststat(coef, Vbj, 3.7)
+#     assert a == b
 
 
-# --- Category K: branch coverage ---
+# # --- Category K: branch coverage ---
 
 
-@pytest.mark.parametrize("tau", [3.7, 2.3, 5.9, 1.5, 0.5])
-def test_woodteststat_fractional_branch(gam, tau):
-    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
-    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
-    _, p, _ = gam._woodteststat(coef, Vbj, tau)
-    assert 0.0 <= p <= 1.0
+# @pytest.mark.parametrize("tau", [3.7, 2.3, 5.9, 1.5, 0.5])
+# def test_woodteststat_fractional_branch(gam, tau):
+#     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
+#     coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+#     _, p, _ = gam._woodteststat(coef, Vbj, tau)
+#     assert 0.0 <= p <= 1.0
 
 
-@pytest.mark.parametrize("tau", [1.0, 2.0, 3.0, 4.0, 5.0])
-def test_woodteststat_integer_branch(gam, tau):
-    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
-    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
-    _, p, _ = gam._woodteststat(coef, Vbj, tau)
-    assert 0.0 <= p <= 1.0
+# @pytest.mark.parametrize("tau", [1.0, 2.0, 3.0, 4.0, 5.0])
+# def test_woodteststat_integer_branch(gam, tau):
+#     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
+#     coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+#     _, p, _ = gam._woodteststat(coef, Vbj, tau)
+#     assert 0.0 <= p <= 1.0
 
 
-def test_woodteststat_stage_c_clamps_rank_deficient(gam):
-    # only 2 real directions exist, tau=3.7 asks for k1=4 -> must clamp
-    Vbj = make_test_Vbj([5.0, 3.0, 1e-18, 1e-18, 1e-18, 1e-18])
-    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
-    _, p, r = gam._woodteststat(coef, Vbj, 3.7)
-    assert 0.0 <= p <= 1.0
-    assert r <= 2
+# def test_woodteststat_stage_c_clamps_rank_deficient(gam):
+#     # only 2 real directions exist, tau=3.7 asks for k1=4 -> must clamp
+#     Vbj = make_test_Vbj([5.0, 3.0, 1e-18, 1e-18, 1e-18, 1e-18])
+#     coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+#     _, p, r = gam._woodteststat(coef, Vbj, 3.7)
+#     assert 0.0 <= p <= 1.0
+#     assert r <= 2
 
 
-# --- Category L: signal vs noise behaviour ---
+# # --- Category L: signal vs noise behaviour ---
 
 
-def test_woodteststat_big_coef_significant(gam):
-    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
-    coef = np.array([10.0, 8.0, 6.0, 4.0, 2.0, 1.0])
-    _, p, _ = gam._woodteststat(coef, Vbj, 3.7)
-    assert p < 0.05
+# def test_woodteststat_big_coef_significant(gam):
+#     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
+#     coef = np.array([10.0, 8.0, 6.0, 4.0, 2.0, 1.0])
+#     _, p, _ = gam._woodteststat(coef, Vbj, 3.7)
+#     assert p < 0.05
 
 
-def test_woodteststat_tiny_coef_not_significant(gam):
-    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
-    coef = np.full(6, 0.01)
-    _, p, _ = gam._woodteststat(coef, Vbj, 3.7)
-    assert p > 0.9
+# def test_woodteststat_tiny_coef_not_significant(gam):
+#     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
+#     coef = np.full(6, 0.01)
+#     _, p, _ = gam._woodteststat(coef, Vbj, 3.7)
+#     assert p > 0.9
 
 
-def test_woodteststat_zero_coef_pval_one(gam):
-    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
-    coef = np.zeros(6)
-    T, p, _ = gam._woodteststat(coef, Vbj, 3.7)
-    assert T == 0.0
-    assert p == 1.0
+# def test_woodteststat_zero_coef_pval_one(gam):
+#     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
+#     coef = np.zeros(6)
+#     T, p, _ = gam._woodteststat(coef, Vbj, 3.7)
+#     assert T == 0.0
+#     assert p == 1.0
 
 
-# --- Category M: scale-known vs scale-estimated ---
+# # --- Category M: scale-known vs scale-estimated ---
 
 
-def test_woodteststat_estimated_scale_runs(gam):
-    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
-    coef = np.array([2.0, 1.5, -1.0, 0.8, 0.3, -0.2])
-    _, p, _ = gam._woodteststat(coef, Vbj, 3.7, res_df=80)
-    assert 0.0 <= p <= 1.0
+# def test_woodteststat_estimated_scale_runs(gam):
+#     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
+#     coef = np.array([2.0, 1.5, -1.0, 0.8, 0.3, -0.2])
+#     _, p, _ = gam._woodteststat(coef, Vbj, 3.7, res_df=80)
+#     assert 0.0 <= p <= 1.0
 
 
-def test_woodteststat_estimated_scale_no_smaller_than_known(gam):
-    # estimating the scale adds uncertainty -> p should be >= the known-scale one
-    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
-    coef = np.array([3.0, 2.0, -1.5, 1.0, 0.5, -0.3])
-    _, p_known, _ = gam._woodteststat(coef, Vbj, 3.7)
-    _, p_est, _ = gam._woodteststat(coef, Vbj, 3.7, res_df=30)
-    assert p_est >= p_known - 1e-9
+# def test_woodteststat_estimated_scale_no_smaller_than_known(gam):
+#     # estimating the scale adds uncertainty -> p should be >= the known-scale one
+#     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
+#     coef = np.array([3.0, 2.0, -1.5, 1.0, 0.5, -0.3])
+#     _, p_known, _ = gam._woodteststat(coef, Vbj, 3.7)
+#     _, p_est, _ = gam._woodteststat(coef, Vbj, 3.7, res_df=30)
+#     assert p_est >= p_known - 1e-9
 
 
-@pytest.mark.parametrize("res_df", [10, 50, 200])
-def test_woodteststat_integer_estimated_uses_F(gam, res_df):
-    # integer tau, estimated scale -> F distribution path
-    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
-    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
-    _, p, _ = gam._woodteststat(coef, Vbj, 4.0, res_df=res_df)
-    assert 0.0 <= p <= 1.0
+# @pytest.mark.parametrize("res_df", [10, 50, 200])
+# def test_woodteststat_integer_estimated_uses_F(gam, res_df):
+#     # integer tau, estimated scale -> F distribution path
+#     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
+#     coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+#     _, p, _ = gam._woodteststat(coef, Vbj, 4.0, res_df=res_df)
+#     assert 0.0 <= p <= 1.0
 
 
-# --- Category N: Monte Carlo validation (statistical correctness) ---
+# # --- Category N: Monte Carlo validation (statistical correctness) ---
 
 
-@pytest.mark.parametrize("tau,beta_seed", [(3.7, 4), (2.3, 0), (5.5, 2)])
-def test_woodteststat_matches_monte_carlo_fractional(gam, tau, beta_seed):
-    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
-    rng = np.random.default_rng(beta_seed + 1000)
-    beta = np.linalg.cholesky(Vbj + 1e-12 * np.eye(6)) @ rng.standard_normal(6)
-    T, p, _ = gam._woodteststat(beta, Vbj, tau)
-    mc = mc_woodteststat_pvalue(gam, Vbj, tau, T, n_sim=30_000, seed=beta_seed + 5000)
-    assert abs(p - mc) < 0.05
+# @pytest.mark.parametrize("tau,beta_seed", [(3.7, 4), (2.3, 0), (5.5, 2)])
+# def test_woodteststat_matches_monte_carlo_fractional(gam, tau, beta_seed):
+#     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
+#     rng = np.random.default_rng(beta_seed + 1000)
+#     beta = np.linalg.cholesky(Vbj + 1e-12 * np.eye(6)) @ rng.standard_normal(6)
+#     T, p, _ = gam._woodteststat(beta, Vbj, tau)
+#     mc = mc_woodteststat_pvalue(gam, Vbj, tau, T, n_sim=30_000, seed=beta_seed + 5000)
+#     assert abs(p - mc) < 0.05
 
 
-def test_woodteststat_matches_monte_carlo_integer(gam):
-    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=3)
-    beta = np.array([1.5, 1.0, -0.8, 0.5, 0.2, -0.1])
-    T, p, _ = gam._woodteststat(beta, Vbj, 4.0)
-    mc = mc_woodteststat_pvalue(gam, Vbj, 4.0, T, n_sim=30_000, seed=4)
-    assert abs(p - mc) < 0.05
+# def test_woodteststat_matches_monte_carlo_integer(gam):
+#     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=3)
+#     beta = np.array([1.5, 1.0, -0.8, 0.5, 0.2, -0.1])
+#     T, p, _ = gam._woodteststat(beta, Vbj, 4.0)
+#     mc = mc_woodteststat_pvalue(gam, Vbj, 4.0, T, n_sim=30_000, seed=4)
+#     assert abs(p - mc) < 0.05

--- a/pygam/tests/test_pvalues.py
+++ b/pygam/tests/test_pvalues.py
@@ -1,0 +1,217 @@
+"""Tests for Wood (2013) p-value helper functions (liu2)."""
+
+import numpy as np
+import pytest
+from scipy import stats
+
+from pygam import LinearGAM
+from pygam.datasets import mcycle
+
+
+@pytest.fixture(scope="module")
+def gam():
+    """A fitted GAM instance, so we can call its _liu2 methods."""
+    X, y = mcycle(return_X_y=True)
+    return LinearGAM().fit(X, y)
+
+
+def mc_pvalue(lambdas, x, n_samples=300_000, seed=0):
+    rng = np.random.default_rng(seed)
+    lam = np.asarray(lambdas, dtype=float)
+    samples = rng.chisquare(1.0, size=(n_samples, len(lam))) @ lam
+    return float((samples > x).mean())
+
+
+def mc_scaled(d, val, k0, n_samples=300_000, seed=0):
+    rng = np.random.default_rng(seed)
+    val = np.asarray(val, dtype=float)
+    Q = rng.chisquare(1.0, size=(n_samples, len(val))) @ val
+    Ck = rng.chisquare(k0, size=n_samples)
+    return float((Q > d * Ck / k0).mean())
+
+
+def wood_weights(k_int_part, nu):
+    rp = nu + 1.0
+    nu1 = (rp + np.sqrt(rp * (2.0 - rp))) / 2.0
+    nu2 = rp - nu1
+    return [1.0] * (k_int_part - 1) + [nu1, nu2]
+
+
+# --- Category A: closed-form standard cases ---
+
+@pytest.mark.parametrize("x", [0.5, 1.0, 2.71, 3.84, 6.63, 10.83])
+def test_liu2_single_chi2_1(gam, x):
+    got = gam._liu2(x, [1.0])
+    expected = float(stats.chi2.sf(x, df=1))
+    assert abs(got - expected) <= 0.03
+
+
+@pytest.mark.parametrize("k", [2, 3, 5, 10])
+def test_liu2_equal_weights_chi2_k(gam, k):
+    x = float(stats.chi2.ppf(0.95, df=k))
+    got = gam._liu2(x, [1.0] * k)
+    assert abs(got - 0.05) <= 0.02
+
+
+@pytest.mark.parametrize("x", [2.0, 4.0, 8.0])
+def test_liu2_scaled_chi2(gam, x):
+    got = gam._liu2(x, [2.0, 2.0])
+    expected = float(stats.chi2.sf(x / 2.0, df=2))
+    assert abs(got - expected) <= 0.02
+
+
+# --- Category B: Wood-style fractional mixtures (vs Monte Carlo) ---
+
+@pytest.mark.parametrize("k_int,nu,xs", [
+    (3, 0.7, [2.0, 5.0, 7.5, 12.0]),
+    (2, 0.3, [1.5, 4.0, 7.0]),
+    (5, 0.9, [3.0, 8.0, 15.0]),
+    (1, 0.5, [0.5, 2.0, 4.5]),
+])
+def test_liu2_wood_mixtures(gam, k_int, nu, xs):
+    val = wood_weights(k_int, nu)
+    for x in xs:
+        got = gam._liu2(x, val)
+        expected = mc_pvalue(val, x, seed=int(k_int * 10 + nu * 100 + x))
+        assert abs(got - expected) <= 0.025
+
+
+# --- Category C: boundary x values ---
+
+def test_liu2_boundary(gam):
+    lambdas = [1.0, 0.7, 0.4, 0.2]
+    assert abs(gam._liu2(0.0, lambdas) - 1.0) <= 0.05
+    assert abs(gam._liu2(-100.0, lambdas) - 1.0) <= 0.01
+    assert abs(gam._liu2(1000.0, lambdas) - 0.0) <= 0.01
+    muQ = sum(lambdas)
+    assert abs(gam._liu2(muQ, lambdas) - mc_pvalue(lambdas, muQ, seed=5)) <= 0.03
+
+
+# --- Category D: degenerate inputs ---
+
+def test_liu2_degenerate(gam):
+    assert gam._liu2(1.0, []) == 1.0
+    assert abs(gam._liu2(3.84, [1.0]) - 0.05) <= 0.005
+    assert gam._liu2(1.0, [0.0] * 3) == 0.0
+    assert gam._liu2(-0.5, [0.0] * 3) == 1.0
+    assert abs(gam._liu2(1.0, [1e-12] * 100) - 0.0) <= 0.01
+
+
+# --- Category E: stress / extreme parameters ---
+
+@pytest.mark.parametrize("x", [1.0, 10.0, 30.0])
+def test_liu2_skewed(gam, x):
+    lambdas = [10.0] + [0.01] * 20
+    assert abs(gam._liu2(x, lambdas) - mc_pvalue(lambdas, x, seed=6)) <= 0.03
+
+
+def test_liu2_high_dim(gam):
+    k = 50
+    x = float(stats.chi2.ppf(0.95, df=k))
+    assert abs(gam._liu2(x, [1.0] * k) - 0.05) <= 0.02
+
+
+@pytest.mark.parametrize("x", [0.5, 2.0, 5.0])
+def test_liu2_exp_decay(gam, x):
+    lambdas = [np.exp(-i * 0.3) for i in range(15)]
+    assert abs(gam._liu2(x, lambdas) - mc_pvalue(lambdas, x, seed=7)) <= 0.03
+
+
+@pytest.mark.parametrize("x", [50.0, 150.0, 500.0])
+def test_liu2_bimodal(gam, x):
+    lambdas = [100.0, 0.01]
+    assert abs(gam._liu2(x, lambdas) - mc_pvalue(lambdas, x, seed=8)) <= 0.03
+
+
+# --- Category F: internal consistency ---
+
+def test_liu2_monotonic(gam):
+    lambdas = [1.0, 0.5, 0.3]
+    xs = np.linspace(0.5, 10, 20)
+    pvals = [gam._liu2(x, lambdas) for x in xs]
+    assert all(pvals[i] >= pvals[i + 1] - 1e-9 for i in range(len(pvals) - 1))
+
+
+def test_liu2_in_range(gam):
+    xs = np.concatenate([np.linspace(-10, 0, 5), np.linspace(0.1, 50, 20)])
+    assert all(0 <= gam._liu2(x, [1.0, 0.7, 0.4, 0.2]) <= 1 for x in xs)
+
+
+def test_liu2_scale_equivariance(gam):
+    lambdas = [1.0, 0.5, 0.2]
+    c = 4.7
+    got1 = gam._liu2(3.0, lambdas)
+    got2 = gam._liu2(c * 3.0, [c * l for l in lambdas])
+    assert abs(got1 - got2) <= 0.001
+
+
+def test_liu2_permutation_invariance(gam):
+    lambdas = [1.0, 0.5, 0.2, 0.05]
+    a = gam._liu2(2.5, lambdas)
+    b = gam._liu2(2.5, list(reversed(lambdas)))
+    c = gam._liu2(2.5, sorted(lambdas))
+    assert abs(a - b) < 1e-10 and abs(a - c) < 1e-10
+
+
+# --- Category G: scaled quadrature (estimated-scale case) ---
+
+@pytest.mark.parametrize("k0", [5, 20, 50, 100])
+def test_quadrature_f_1_k0(gam, k0):
+    d = 4.0
+    got = gam._liu2_scaled_quadrature(d, [1.0], k0)
+    expected = float(stats.f.sf(d, dfn=1, dfd=k0))
+    assert abs(got - expected) <= 0.02
+
+
+@pytest.mark.parametrize("k,k0", [(3, 30), (5, 100), (8, 50)])
+def test_quadrature_f_k_k0(gam, k, k0):
+    d = 6.0
+    got = gam._liu2_scaled_quadrature(d, [1.0] * k, k0)
+    expected = float(stats.f.sf(d / k, dfn=k, dfd=k0))
+    assert abs(got - expected) <= 0.025
+
+
+@pytest.mark.parametrize("k0", [20, 100])
+def test_quadrature_wood_mixture(gam, k0):
+    val = wood_weights(3, 0.4)
+    d = 5.0
+    got = gam._liu2_scaled_quadrature(d, val, k0)
+    expected = mc_scaled(d, val, k0, seed=9)
+    assert abs(got - expected) <= 0.03
+
+
+def test_quadrature_converges_to_plain(gam):
+    val = wood_weights(2, 0.5)
+    plain = gam._liu2(4.0, val)
+    scaled = gam._liu2_scaled_quadrature(4.0, val, k0=10_000)
+    assert abs(scaled - plain) <= 0.005
+
+
+# --- Category H: heavy Monte Carlo ---
+
+@pytest.mark.parametrize("lambdas,xs", [
+    ([1.0, 0.5, 0.3, 0.1], [0.5, 1.5, 3.0, 6.0, 10.0]),
+    ([2.0, 1.5, 1.0, 0.5, 0.2], [1.0, 4.0, 8.0, 14.0]),
+    (wood_weights(3, 0.7), [2.0, 5.0, 8.0, 15.0]),
+    (wood_weights(5, 0.2), [3.0, 7.0, 12.0, 20.0]),
+    ([0.95, 0.92, 0.88, 0.85, 0.5, 0.3, 0.1], [1.0, 3.0, 6.0, 10.0]),
+])
+def test_liu2_monte_carlo(gam, lambdas, xs):
+    for x in xs:
+        got = gam._liu2(x, lambdas)
+        expected = mc_pvalue(lambdas, x, n_samples=300_000, seed=int(x * 7 + 11))
+        tol = 0.025 if expected > 0.01 else 0.01
+        assert abs(got - expected) <= tol
+
+
+# --- Category I: random configurations ---
+
+def test_liu2_random_configs(gam):
+    rng = np.random.default_rng(2024)
+    for trial in range(15):
+        k = int(rng.integers(2, 12))
+        lambdas = rng.uniform(0.05, 3.0, size=k).tolist()
+        x = float(rng.uniform(0.5, sum(lambdas) * 2))
+        got = gam._liu2(x, lambdas)
+        expected = mc_pvalue(lambdas, x, seed=trial + 200)
+        assert abs(got - expected) <= 0.03

--- a/pygam/tests/test_pvalues.py
+++ b/pygam/tests/test_pvalues.py
@@ -2,10 +2,9 @@
 
 import numpy as np
 import pytest
-from scipy import stats
-
 from pygam import LinearGAM
 from pygam.datasets import mcycle
+from scipy import stats
 
 
 @pytest.fixture(scope="module")
@@ -65,7 +64,7 @@ def test_liu2_scaled_chi2(gam, x):
 
 
 @pytest.mark.parametrize(
-    "k_int,nu,xs",
+    ("k_int", "nu", "xs"),
     [
         (3, 0.7, [2.0, 5.0, 7.5, 12.0]),
         (2, 0.3, [1.5, 4.0, 7.0]),
@@ -173,7 +172,7 @@ def test_quadrature_f_1_k0(gam, k0):
     assert abs(got - expected) <= 0.02
 
 
-@pytest.mark.parametrize("k,k0", [(3, 30), (5, 100), (8, 50)])
+@pytest.mark.parametrize(("k", "k0"), [(3, 30), (5, 100), (8, 50)])
 def test_quadrature_f_k_k0(gam, k, k0):
     d = 6.0
     got = gam._liu2_scaled_quadrature(d, [1.0] * k, k0)
@@ -201,7 +200,7 @@ def test_quadrature_converges_to_plain(gam):
 
 
 @pytest.mark.parametrize(
-    "lambdas,xs",
+    ("lambdas", "xs"),
     [
         ([1.0, 0.5, 0.3, 0.1], [0.5, 1.5, 3.0, 6.0, 10.0]),
         ([2.0, 1.5, 1.0, 0.5, 0.2], [1.0, 4.0, 8.0, 14.0]),
@@ -232,176 +231,367 @@ def test_liu2_random_configs(gam):
         assert abs(got - expected) <= 0.03
 
 
-""" NEW TEST CASES UNDER PROGRESS FOR QR MODIFIED WOOD TEST STATISTIC FUNCTION"""
-
-# """Tests for Wood (2013) p-value helper function (_woodteststat)."""
-
-
-# def make_test_Vbj(eigenvalues, seed=0):
-#     """Build a q x q covariance with the given eigenvalues (random directions)."""
-#     eigenvalues = np.asarray(eigenvalues, dtype=float)
-#     q = len(eigenvalues)
-#     rng = np.random.default_rng(seed)
-#     A = rng.standard_normal((q, q))
-#     Q, _ = np.linalg.qr(A)
-#     return Q @ np.diag(eigenvalues) @ Q.T
+# =====================================================================
+# Tests for Wood (2013) test statistic (_woodteststat)
+# =====================================================================
+# _woodteststat now takes the term's model matrix Xj and computes the
+# statistic in curve space. make_Xj builds an Xj whose column-centered
+# form is orthonormal, so qr(Xj) gives R = I and the statistic is
+# computed directly on the supplied Vbj (no rotation). This lets each
+# unit test specify, via Vbj, exactly the matrix to eigendecompose.
 
 
-# def mc_woodteststat_pvalue(gam, Vbj, edf_j, T_obs, n_sim=20_000, seed=0):
-#     """Monte-Carlo p-value: simulate beta ~ N(0, Vbj), count T_sim > T_obs."""
-#     rng = np.random.default_rng(seed)
-#     q = Vbj.shape[0]
-#     L = np.linalg.cholesky(Vbj + 1e-12 * np.eye(q))
-#     count = 0
-#     for _ in range(n_sim):
-#         beta = L @ rng.standard_normal(q)
-#         T_sim, _, _ = gam._woodteststat(beta, Vbj, edf_j)
-#         if T_sim > T_obs:
-#             count += 1
-#     return count / n_sim
+def make_test_Vbj(eigenvalues, seed=0):
+    """Build a q x q covariance with the given eigenvalues (random directions)."""
+    eigenvalues = np.asarray(eigenvalues, dtype=float)
+    q = len(eigenvalues)
+    rng = np.random.default_rng(seed)
+    A = rng.standard_normal((q, q))
+    Q, _ = np.linalg.qr(A)
+    return Q @ np.diag(eigenvalues) @ Q.T
 
 
-# # --- Category J: Stage A,B,C structural invariants ---
+def make_Xj(q):
+    """Model matrix whose column-centered form is orthonormal.
+
+    The columns are orthonormal and orthogonal to the constant vector, so
+    column-centering is a no-op and qr(Xj) yields R = I. The curve-space
+    transform W = R Vbj R^T then reduces to Vbj, so _woodteststat operates
+    directly on the supplied Vbj and coefficients.
+    """
+    n = q + 1
+    rng = np.random.default_rng(12345)
+    M = np.column_stack([np.ones(n), rng.standard_normal((n, q))])
+    Q, _ = np.linalg.qr(M)
+    return Q[:, 1 : q + 1]
 
 
-# def test_woodteststat_returns_three_floats(gam):
-#     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
-#     coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
-#     T, p, r = gam._woodteststat(coef, Vbj, 3.7)
-#     assert isinstance(T, float) and isinstance(p, float) and isinstance(r, int)
+def mc_woodteststat_pvalue(gam, Vbj, edf_j, T_obs, Xj, n_sim=20_000, seed=0):
+    """Monte-Carlo p-value: simulate beta ~ N(0, Vbj), count T_sim > T_obs."""
+    rng = np.random.default_rng(seed)
+    q = Vbj.shape[0]
+    L = np.linalg.cholesky(Vbj + 1e-12 * np.eye(q))
+    count = 0
+    for _ in range(n_sim):
+        beta = L @ rng.standard_normal(q)
+        T_sim, _, _ = gam._woodteststat(beta, Vbj, edf_j, Xj)
+        if T_sim > T_obs:
+            count += 1
+    return count / n_sim
 
 
-# def test_woodteststat_pval_in_unit_interval(gam):
-#     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
-#     coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
-#     _, p, _ = gam._woodteststat(coef, Vbj, 3.7)
-#     assert 0.0 <= p <= 1.0
+# --- Category J: Stage A,B,C structural invariants ---
 
 
-# def test_woodteststat_degenerate_Vbj_returns_pval_one(gam):
-#     # all-zero covariance: term is effectively zero, p must be 1
-#     Vbj = np.zeros((6, 6))
-#     coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
-#     T, p, r = gam._woodteststat(coef, Vbj, 3.7)
-#     assert T == 0.0
-#     assert p == 1.0
-#     assert r == 1
+def test_woodteststat_returns_three_floats(gam):
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
+    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+    T, p, r = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6))
+    assert isinstance(T, float) and isinstance(p, float) and isinstance(r, int)
 
 
-# def test_woodteststat_near_zero_Vbj_returns_pval_one(gam):
-#     # all eigenvalues 1e-20: still degenerate
-#     Vbj = make_test_Vbj([1e-20] * 6)
-#     coef = np.ones(6)
-#     _, p, _ = gam._woodteststat(coef, Vbj, 3.7)
-#     assert p == 1.0
+def test_woodteststat_pval_in_unit_interval(gam):
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
+    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+    _, p, _ = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6))
+    assert 0.0 <= p <= 1.0
 
 
-# def test_woodteststat_deterministic(gam):
-#     # same inputs -> same outputs
-#     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=7)
-#     coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
-#     a = gam._woodteststat(coef, Vbj, 3.7)
-#     b = gam._woodteststat(coef, Vbj, 3.7)
-#     assert a == b
+def test_woodteststat_degenerate_Vbj_returns_pval_one(gam):
+    # all-zero covariance: term is effectively zero, p must be 1
+    Vbj = np.zeros((6, 6))
+    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+    T, p, r = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6))
+    assert T == 0.0
+    assert p == 1.0
+    assert r == 1
 
 
-# # --- Category K: branch coverage ---
+def test_woodteststat_near_zero_Vbj_returns_pval_one(gam):
+    # all eigenvalues 1e-20: still degenerate
+    Vbj = make_test_Vbj([1e-20] * 6)
+    coef = np.ones(6)
+    _, p, _ = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6))
+    assert p == 1.0
 
 
-# @pytest.mark.parametrize("tau", [3.7, 2.3, 5.9, 1.5, 0.5])
-# def test_woodteststat_fractional_branch(gam, tau):
-#     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
-#     coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
-#     _, p, _ = gam._woodteststat(coef, Vbj, tau)
-#     assert 0.0 <= p <= 1.0
+def test_woodteststat_deterministic(gam):
+    # same inputs -> same outputs
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=7)
+    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+    a = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6))
+    b = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6))
+    assert a == b
 
 
-# @pytest.mark.parametrize("tau", [1.0, 2.0, 3.0, 4.0, 5.0])
-# def test_woodteststat_integer_branch(gam, tau):
-#     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
-#     coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
-#     _, p, _ = gam._woodteststat(coef, Vbj, tau)
-#     assert 0.0 <= p <= 1.0
+# --- Category K: branch coverage ---
 
 
-# def test_woodteststat_stage_c_clamps_rank_deficient(gam):
-#     # only 2 real directions exist, tau=3.7 asks for k1=4 -> must clamp
-#     Vbj = make_test_Vbj([5.0, 3.0, 1e-18, 1e-18, 1e-18, 1e-18])
-#     coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
-#     _, p, r = gam._woodteststat(coef, Vbj, 3.7)
-#     assert 0.0 <= p <= 1.0
-#     assert r <= 2
+@pytest.mark.parametrize("tau", [3.7, 2.3, 5.9, 1.5, 0.5])
+def test_woodteststat_fractional_branch(gam, tau):
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
+    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+    _, p, _ = gam._woodteststat(coef, Vbj, tau, make_Xj(6))
+    assert 0.0 <= p <= 1.0
 
 
-# # --- Category L: signal vs noise behaviour ---
+@pytest.mark.parametrize("tau", [1.0, 2.0, 3.0, 4.0, 5.0])
+def test_woodteststat_integer_branch(gam, tau):
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
+    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+    _, p, _ = gam._woodteststat(coef, Vbj, tau, make_Xj(6))
+    assert 0.0 <= p <= 1.0
 
 
-# def test_woodteststat_big_coef_significant(gam):
-#     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
-#     coef = np.array([10.0, 8.0, 6.0, 4.0, 2.0, 1.0])
-#     _, p, _ = gam._woodteststat(coef, Vbj, 3.7)
-#     assert p < 0.05
+def test_woodteststat_stage_c_clamps_rank_deficient(gam):
+    # only 2 real directions exist, tau=3.7 asks for k1=4 -> must clamp
+    Vbj = make_test_Vbj([5.0, 3.0, 1e-18, 1e-18, 1e-18, 1e-18])
+    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+    _, p, r = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6))
+    assert 0.0 <= p <= 1.0
+    assert r <= 2
 
 
-# def test_woodteststat_tiny_coef_not_significant(gam):
-#     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
-#     coef = np.full(6, 0.01)
-#     _, p, _ = gam._woodteststat(coef, Vbj, 3.7)
-#     assert p > 0.9
+# --- Category L: signal vs noise behaviour ---
 
 
-# def test_woodteststat_zero_coef_pval_one(gam):
-#     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
-#     coef = np.zeros(6)
-#     T, p, _ = gam._woodteststat(coef, Vbj, 3.7)
-#     assert T == 0.0
-#     assert p == 1.0
+def test_woodteststat_big_coef_significant(gam):
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
+    coef = np.array([10.0, 8.0, 6.0, 4.0, 2.0, 1.0])
+    _, p, _ = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6))
+    assert p < 0.05
 
 
-# # --- Category M: scale-known vs scale-estimated ---
+def test_woodteststat_tiny_coef_not_significant(gam):
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
+    coef = np.full(6, 0.01)
+    _, p, _ = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6))
+    assert p > 0.9
 
 
-# def test_woodteststat_estimated_scale_runs(gam):
-#     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
-#     coef = np.array([2.0, 1.5, -1.0, 0.8, 0.3, -0.2])
-#     _, p, _ = gam._woodteststat(coef, Vbj, 3.7, res_df=80)
-#     assert 0.0 <= p <= 1.0
+def test_woodteststat_zero_coef_pval_one(gam):
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
+    coef = np.zeros(6)
+    T, p, _ = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6))
+    assert T == 0.0
+    assert p == 1.0
 
 
-# def test_woodteststat_estimated_scale_no_smaller_than_known(gam):
-#     # estimating the scale adds uncertainty -> p should be >= the known-scale one
-#     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
-#     coef = np.array([3.0, 2.0, -1.5, 1.0, 0.5, -0.3])
-#     _, p_known, _ = gam._woodteststat(coef, Vbj, 3.7)
-#     _, p_est, _ = gam._woodteststat(coef, Vbj, 3.7, res_df=30)
-#     assert p_est >= p_known - 1e-9
+# --- Category M: scale-known vs scale-estimated ---
 
 
-# @pytest.mark.parametrize("res_df", [10, 50, 200])
-# def test_woodteststat_integer_estimated_uses_F(gam, res_df):
-#     # integer tau, estimated scale -> F distribution path
-#     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
-#     coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
-#     _, p, _ = gam._woodteststat(coef, Vbj, 4.0, res_df=res_df)
-#     assert 0.0 <= p <= 1.0
+def test_woodteststat_estimated_scale_runs(gam):
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
+    coef = np.array([2.0, 1.5, -1.0, 0.8, 0.3, -0.2])
+    _, p, _ = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6), res_df=80)
+    assert 0.0 <= p <= 1.0
 
 
-# # --- Category N: Monte Carlo validation (statistical correctness) ---
+def test_woodteststat_estimated_scale_no_smaller_than_known(gam):
+    # estimating the scale adds uncertainty -> p should be >= the known-scale one
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
+    coef = np.array([3.0, 2.0, -1.5, 1.0, 0.5, -0.3])
+    _, p_known, _ = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6))
+    _, p_est, _ = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6), res_df=30)
+    assert p_est >= p_known - 1e-9
 
 
-# @pytest.mark.parametrize("tau,beta_seed", [(3.7, 4), (2.3, 0), (5.5, 2)])
-# def test_woodteststat_matches_monte_carlo_fractional(gam, tau, beta_seed):
-#     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
-#     rng = np.random.default_rng(beta_seed + 1000)
-#     beta = np.linalg.cholesky(Vbj + 1e-12 * np.eye(6)) @ rng.standard_normal(6)
-#     T, p, _ = gam._woodteststat(beta, Vbj, tau)
-#     mc = mc_woodteststat_pvalue(gam, Vbj, tau, T, n_sim=30_000, seed=beta_seed + 5000)
-#     assert abs(p - mc) < 0.05
+@pytest.mark.parametrize("res_df", [10, 50, 200])
+def test_woodteststat_integer_estimated_uses_F(gam, res_df):
+    # integer tau, estimated scale -> F distribution path
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
+    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+    _, p, _ = gam._woodteststat(coef, Vbj, 4.0, make_Xj(6), res_df=res_df)
+    assert 0.0 <= p <= 1.0
 
 
-# def test_woodteststat_matches_monte_carlo_integer(gam):
-#     Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=3)
-#     beta = np.array([1.5, 1.0, -0.8, 0.5, 0.2, -0.1])
-#     T, p, _ = gam._woodteststat(beta, Vbj, 4.0)
-#     mc = mc_woodteststat_pvalue(gam, Vbj, 4.0, T, n_sim=30_000, seed=4)
-#     assert abs(p - mc) < 0.05
+# --- Category N: Monte Carlo validation (statistical correctness) ---
+
+
+@pytest.mark.parametrize(("tau", "beta_seed"), [(3.7, 4), (2.3, 0), (5.5, 2)])
+def test_woodteststat_matches_monte_carlo_fractional(gam, tau, beta_seed):
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=1)
+    Xj = make_Xj(6)
+    rng = np.random.default_rng(beta_seed + 1000)
+    beta = np.linalg.cholesky(Vbj + 1e-12 * np.eye(6)) @ rng.standard_normal(6)
+    T, p, _ = gam._woodteststat(beta, Vbj, tau, Xj)
+    mc = mc_woodteststat_pvalue(
+        gam, Vbj, tau, T, Xj, n_sim=30_000, seed=beta_seed + 5000
+    )
+    assert abs(p - mc) < 0.05
+
+
+def test_woodteststat_matches_monte_carlo_integer(gam):
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2], seed=3)
+    Xj = make_Xj(6)
+    beta = np.array([1.5, 1.0, -0.8, 0.5, 0.2, -0.1])
+    T, p, _ = gam._woodteststat(beta, Vbj, 4.0, Xj)
+    mc = mc_woodteststat_pvalue(gam, Vbj, 4.0, T, Xj, n_sim=30_000, seed=4)
+    assert abs(p - mc) < 0.05
+
+
+# --- Category O: real (non-orthonormal) basis exercises the curve-space path ---
+
+
+def test_woodteststat_uses_R_rotation_real_basis(gam):
+    """Regression test for the dropped-R bug.
+
+    The statistic is defined in curve space: it must rotate Vbj and coef by R
+    from qr(Xj), i.e. eigendecompose W = R Vbj R^T, not Vbj directly. With a
+    real (non-orthonormal) basis the rotation changes the answer, so a real Xj
+    must give a different statistic than the no-rotation (R = I) case obtained
+    from make_Xj. If R were dropped (Vbj eigendecomposed directly, ignoring Xj)
+    the two would be identical and this test would fail.
+
+    This only manifests at FRACTIONAL edf: at integer edf the full inverse is
+    basis-free, R cancels, and the curve-space and raw-Vbj statistics coincide.
+    """
+    rng = np.random.default_rng(0)
+    Xj_real = rng.standard_normal((100, 6))  # genuine basis -> R != I
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
+    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+
+    T_real, _, _ = gam._woodteststat(coef, Vbj, 3.7, Xj_real)  # rotated (curve space)
+    T_identity, _, _ = gam._woodteststat(coef, Vbj, 3.7, make_Xj(6))  # R = I -> raw Vbj
+
+    # the rotation must actually change the statistic
+    assert not np.isclose(T_real, T_identity, rtol=1e-3)
+
+
+def test_woodteststat_full_rank_edf_R_cancels(gam):
+    """Counterpart: only at FULL-RANK edf (tau == q, every direction inverted)
+    does the rotation cancel, so a real basis and the no-rotation case give the
+    same statistic (the full inverse is basis-free). At fractional or truncated
+    edf the rotation does not cancel - see the test above.
+    """
+    rng = np.random.default_rng(0)
+    Xj_real = rng.standard_normal((100, 6))
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
+    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+
+    # tau == q == 6: full inverse, basis-free
+    T_real, _, _ = gam._woodteststat(coef, Vbj, 6.0, Xj_real)
+    T_identity, _, _ = gam._woodteststat(coef, Vbj, 6.0, make_Xj(6))
+
+    assert np.isclose(T_real, T_identity, rtol=1e-6)
+
+
+def test_woodteststat_real_basis_valid_output(gam):
+    """A genuine non-orthonormal basis still returns a well-formed result."""
+    rng = np.random.default_rng(1)
+    Xj = rng.standard_normal((100, 6))
+    Vbj = make_test_Vbj([5.0, 3.0, 2.0, 1.0, 0.5, 0.2])
+    coef = np.array([1.0, -0.5, 0.8, 0.3, -0.2, 0.1])
+    T, p, r = gam._woodteststat(coef, Vbj, 3.7, Xj)
+    assert T >= 0.0
+    assert 0.0 <= p <= 1.0
+    assert isinstance(r, int)
+
+
+# --- Category P: validation against compiled mgcv (mgcv 1.8-41 testStat) ---
+#
+# The reference stat/pval below were produced by running mgcv:::testStat on the
+# exact same inputs (real non-orthonormal bases, fractional and integer edf,
+# known and estimated scale). The bases are pre-centered so pyGAM's internal
+# column-centering is a no-op and both QR the identical matrix.
+#
+# The statistic matches mgcv to ~1e-9 across every case. The p-value matches
+# closely except a wider gap on the small-sample estimated-scale case (c6):
+# mgcv's psum.chisq uses Davies' method while pyGAM uses the Liu et al. (2009)
+# approximation, and the two disagree most in that tail. Hence stat is checked
+# tightly and pval loosely.
+
+
+def _mgcv_case(name):
+    """Regenerate the exact (X, V, coef, edf, res_df) validated against mgcv.
+
+    PCG64 (np.random.default_rng) is version-stable, so these reproduce the
+    arrays mgcv:::testStat was evaluated on bit-for-bit.
+    """
+    specs = [
+        (
+            "c1_frac_known",
+            (20, 4),
+            [4.0, 2.0, 1.0, 0.5],
+            1,
+            [1.0, -0.5, 0.8, 0.3],
+            2.7,
+            -1,
+        ),
+        (
+            "c2_frac_estscale",
+            (30, 5),
+            [5.0, 3.0, 2.0, 1.0, 0.4],
+            2,
+            [2.0, 1.0, -0.7, 0.5, 0.2],
+            3.4,
+            25,
+        ),
+        (
+            "c3_int_full",
+            (25, 4),
+            [3.0, 2.0, 1.0, 0.5],
+            3,
+            [1.5, -1.0, 0.6, 0.2],
+            4.0,
+            -1,
+        ),
+        (
+            "c4_int_trunc",
+            (40, 6),
+            [6.0, 4.0, 3.0, 2.0, 1.0, 0.5],
+            4,
+            [1.0, -0.5, 0.8, 0.3, -0.2, 0.1],
+            4.0,
+            -1,
+        ),
+        (
+            "c5_frac_big",
+            (100, 8),
+            [8.0, 6.0, 5.0, 3.0, 2.0, 1.0, 0.6, 0.3],
+            5,
+            [1.2, -0.8, 1.0, 0.5, -0.3, 0.4, 0.1, -0.05],
+            5.6,
+            -1,
+        ),
+        ("c6_frac_estscale_sm", (15, 3), [3.0, 1.5, 0.7], 6, [1.0, 0.5, -0.3], 1.8, 12),
+    ]
+    rng = np.random.default_rng(100)
+    out = {}
+    for nm, (n, q), ev, vseed, coef, edf, res_df in specs:
+        X = rng.standard_normal((n, q))
+        X = X - X.mean(axis=0)
+        vrng = np.random.default_rng(vseed)
+        Q, _ = np.linalg.qr(vrng.standard_normal((q, q)))
+        V = Q @ np.diag(np.asarray(ev, dtype=float)) @ Q.T
+        out[nm] = (X, V, np.array(coef), edf, res_df)
+    return out[name]
+
+
+# (stat, pval) from mgcv 1.8-41 mgcv:::testStat
+MGCV_REFERENCE = {
+    "c1_frac_known": (1.018550885, 0.7881442045),
+    "c2_frac_estscale": (6.112807193, 0.3405266276),
+    "c3_int_full": (2.864625904, 0.5807294373),
+    "c4_int_trunc": (0.4571566394, 0.9775355139),
+    "c5_frac_big": (0.9684885577, 0.9877958744),
+    "c6_frac_estscale_sm": (0.109650584, 0.9185588708),
+}
+
+
+@pytest.mark.parametrize("case", list(MGCV_REFERENCE))
+def test_woodteststat_matches_mgcv_stat(gam, case):
+    """The test statistic must match compiled mgcv to high precision."""
+    X, V, coef, edf, res_df = _mgcv_case(case)
+    stat_mgcv, _ = MGCV_REFERENCE[case]
+    T, _, _ = gam._woodteststat(coef, V, edf, X, res_df)
+    assert abs(T - stat_mgcv) < 1e-6
+
+
+@pytest.mark.parametrize("case", list(MGCV_REFERENCE))
+def test_woodteststat_matches_mgcv_pval(gam, case):
+    """The p-value must match mgcv within the Davies-vs-Liu approximation gap."""
+    X, V, coef, edf, res_df = _mgcv_case(case)
+    _, pval_mgcv = MGCV_REFERENCE[case]
+    _, p, _ = gam._woodteststat(coef, V, edf, X, res_df)
+    assert abs(p - pval_mgcv) < 0.05

--- a/pygam/utils.py
+++ b/pygam/utils.py
@@ -571,12 +571,15 @@ def sig_code(p_value):
 
     Arguments
     ---------
-    p_value : float on [0, 1]
+    p_value : float on [0, 1], or nan (e.g. for the intercept)
 
     Returns
     -------
     str
     """
+    # intercept and other untested terms return nan -> blank code
+    if not np.isfinite(p_value):
+        return " "
     assert 0 <= p_value <= 1, "p_value must be on [0, 1]"
     if p_value < 0.001:
         return "***"


### PR DESCRIPTION
Replaces the current method of computing p values in PyGAM with the method mentioned in Simon Wood's "On p-values for smooth components of an extended generalized additive model" (Biometrika 100:221-228), addressing issue #163.