### PR TITLE
Fix grammatical error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ GAMs extend generalized linear models by allowing non-linear functions of featur
 
 Since GAMs are additive, it is easy to examine the effect of each $X_i$ on $y$ individually while holding all other predictors constant.
 
-As a result, GAMs are a class of very flexible and interpretable models, which also make it is easy to incorporate prior knowledge and control overfitting.
+As a result, GAMs are a class of very flexible and interpretable models, which also make it easy to incorporate prior knowledge and control overfitting.
 
 ## Citing pyGAM
 Please consider citing pyGAM if it has helped you in your research or work:


### PR DESCRIPTION
## Summary

This PR fixes a grammatical error in the README.

### Changes made

* Corrected the phrase:

  * `make it is easy` → `make it easy`

This improves the readability and correctness of the documentation without changing its meaning.
