### PR TITLE
[DOC] Fix typos and stray punctuation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,7 +72,7 @@ pyGAM is tested on Python 3.10+ and depends on ``NumPy``, ``SciPy``, and ``progr
 
 In addition to the above dependencies, the ``pygam.datasets`` submodule relies on ``Pandas``.
 
-See `pyproject.toml <https://github.com/dswah/pyGAM/blob/main/pyproject.toml>`_ for detailed version information).
+See `pyproject.toml <https://github.com/dswah/pyGAM/blob/main/pyproject.toml>`_ for detailed version information.
 
 |
 

--- a/pygam/pygam.py
+++ b/pygam/pygam.py
@@ -1,4 +1,4 @@
-"""pyGAM Model Clases"""
+"""pyGAM Model Classes"""
 
 import warnings
 from collections import OrderedDict, defaultdict

--- a/pygam/terms.py
+++ b/pygam/terms.py
@@ -62,7 +62,7 @@ class Term(Core):
         whether to fit a linear model of the feature
 
     fit_splines : bool
-        whether to fit spliens to the feature
+        whether to fit splines to the feature
 
     Attributes
     ----------


### PR DESCRIPTION
Corrects three small documentation issues found while reading through the docstrings and Sphinx docs:

- pygam/terms.py: 'spliens' -> 'splines' in the Term class' fit_splines parameter docstring.
- pygam/pygam.py: module docstring 'pyGAM Model Clases' -> 'pyGAM Model Classes'.
- docs/index.rst: removed an orphaned closing parenthesis after the pyproject.toml version-info sentence; there was no matching opening parenthesis in the sentence.

No code behavior changes; pytest -s pygam/tests still passes 162 passed, 1 skipped, matching main's baseline.