### PR TITLE
   [BUG] Fix validate_callback_data flagging local variables as missing args

### DIFF
--- a/pygam/callbacks.py
+++ b/pygam/callbacks.py
@@ -34,7 +34,7 @@ def validate_callback_data(method):
         -------
         method's output
         """
-        expected = method.__code__.co_varnames
+        expected = method.__code__.co_varnames[: method.__code__.co_argcount]
 
         # rename current gam object
         if "self" in kwargs:

--- a/pygam/tests/test_callbacks.py
+++ b/pygam/tests/test_callbacks.py
@@ -1,0 +1,56 @@
+import pytest
+
+from pygam import LinearGAM
+from pygam.callbacks import CallBack, validate_callback_data
+
+
+class _LocalVarCallback(CallBack):
+    """A minimal custom callback that declares a local variable inside
+    on_loop_start. Regression test for validate_callback_data
+    incorrectly treating local variables as required arguments.
+    """
+
+    def on_loop_start(self, gam):
+        # this local variable should NOT be treated as a required
+        # keyword argument by validate_callback_data
+        step_threshold = 0.05
+        return step_threshold
+
+
+def test_validate_callback_data_ignores_local_variables():
+    """
+    check that a callback method's internal local variables are not
+    mistaken for required arguments pulled from the training loop's
+    variables dict
+    """
+    wrapped = validate_callback_data(_LocalVarCallback.on_loop_start)
+    # should not raise AssertionError: CallBack cannot reference: step_threshold
+    result = wrapped(_LocalVarCallback(), gam=None)
+    assert result == 0.05
+
+
+def test_validate_callback_data_still_flags_missing_arguments():
+    """
+    check that validate_callback_data still enforces that genuine
+    formal parameters are supplied
+    """
+
+    class NeedsY(CallBack):
+        def on_loop_start(self, gam, y):
+            return y
+
+    wrapped = validate_callback_data(NeedsY.on_loop_start)
+    with pytest.raises(AssertionError, match="CallBack cannot reference: y"):
+        wrapped(NeedsY(), gam=None)
+
+
+def test_gam_fit_with_custom_local_var_callback(mcycle_X_y):
+    """
+    end-to-end check that a GAM can be fit with a custom callback that
+    declares local variables, without raising
+    """
+    X, y = mcycle_X_y
+    gam = LinearGAM(callbacks=[_LocalVarCallback()])
+    gam.fit(X, y)
+    assert gam._is_fitted
+    assert len(gam.logs_[str(gam.callbacks[-1])]) > 0


### PR DESCRIPTION
method.__code__.co_varnames includes every local variable declared inside a function body, not just its formal parameters. Since validate_callback_data used co_varnames directly to determine which keys a callback needs pulled from the training loop's variables dict, any custom CallBack.on_loop_start or on_loop_end that declares its own local variables was incorrectly flagged as a missing argument and raised: AssertionError: CallBack cannot reference: step_threshold

Fix: slice co_varnames down to co_argcount, which isolates the function's formal parameters from its internal locals. Built-in callbacks (Deviance/Diffs/Accuracy) are unaffected since none of them declare local variables, which is also why this had gone unnoticed.

Adds pygam/tests/test_callbacks.py with a unit test reproducing the original AssertionError, a check that missing genuine arguments are still caught, and an end-to-end GAM.fit() using a custom callback with a local variable.

Testing: pytest -s pygam/tests -> 165 passed, 1 skipped, matching main's baseline.

Fixes #596